### PR TITLE
Enhance the Affine Loop Perfection Pass

### DIFF
--- a/lib/TaskflowDialect/Transforms/Optimizations/AffineLoopPerfectionPass.cpp
+++ b/lib/TaskflowDialect/Transforms/Optimizations/AffineLoopPerfectionPass.cpp
@@ -57,6 +57,87 @@ static bool hasSideEffect(Operation *op) {
   return true;
 }
 
+static bool usesLoopResult(Operation *op, affine::AffineForOp loop) {
+  return llvm::any_of(op->getOperands(), [&](Value operand) {
+    return llvm::is_contained(loop.getResults(), operand);
+  });
+}
+
+static LogicalResult checkLoopBandSupported(AffineLoopBand &loop_band) {
+  for (size_t i = loop_band.size() - 1; i > 0; i--) {
+    affine::AffineForOp loop = loop_band[i - 1];
+    affine::AffineForOp child_loop = loop_band[i];
+
+    bool is_prologue = true;
+    bool has_prologue_side_effect = false;
+    bool has_epilogue_side_effect = false;
+
+    for (Operation &op : loop.getRegion().front()) {
+      if (&op == child_loop) {
+        is_prologue = false;
+        continue;
+      }
+
+      if (isa<affine::AffineYieldOp>(&op)) {
+        continue;
+      }
+
+      if (llvm::any_of(op.getResultTypes(),
+                       [](Type type) { return isa<MemRefType>(type); })) {
+        llvm::errs() << "[LoopPerfection] Skipping unsupported loop band: "
+                        "memref-producing operation.\n";
+        return failure();
+      }
+
+      if (isa<func::CallOp>(&op)) {
+        llvm::errs() << "[LoopPerfection] Skipping unsupported loop band: "
+                        "function call operation.\n";
+        return failure();
+      }
+
+      if (!is_prologue && usesLoopResult(&op, child_loop)) {
+        llvm::errs()
+            << "[LoopPerfection] Skipping unsupported loop band: epilogue "
+               "operation uses a child loop result.\n";
+        return failure();
+      }
+
+      if (hasSideEffect(&op)) {
+        if (is_prologue) {
+          has_prologue_side_effect = true;
+        } else {
+          has_epilogue_side_effect = true;
+        }
+      }
+    }
+
+    ArrayRef<affine::AffineForOp> inner_loops =
+        ArrayRef<affine::AffineForOp>(loop_band).drop_front(i);
+
+    if (has_prologue_side_effect) {
+      for (affine::AffineForOp inner_loop : inner_loops) {
+        if (!inner_loop.hasConstantLowerBound()) {
+          llvm::errs() << "[LoopPerfection] Skipping unsupported loop band: "
+                          "non-constant lower bound.\n";
+          return failure();
+        }
+      }
+    }
+
+    if (has_epilogue_side_effect) {
+      for (affine::AffineForOp inner_loop : inner_loops) {
+        if (!inner_loop.getStepAsInt() || !inner_loop.hasConstantUpperBound()) {
+          llvm::errs() << "[LoopPerfection] Skipping unsupported loop band: "
+                          "non-constant upper bound or step.\n";
+          return failure();
+        }
+      }
+    }
+  }
+
+  return success();
+}
+
 // Collects loop bands from a function.
 static void collectLoopBands(func::FuncOp func_op,
                              SmallVector<AffineLoopBand> &loop_bands) {
@@ -192,11 +273,15 @@ createEpilogueCondition(OpBuilder &builder, Location loc,
 // Sinks all operations into the innermost loop with condition execution.
 static LogicalResult applyLoopPerfection(AffineLoopBand &loop_band) {
   if (loop_band.empty()) {
-    return failure();
+    return success();
   }
 
   llvm::errs() << "[LoopPerfection] Processing loop band with "
                << loop_band.size() << " loops.\n";
+
+  if (failed(checkLoopBandSupported(loop_band))) {
+    return success();
+  }
 
   affine::AffineForOp innermost_loop = loop_band.back();
   OpBuilder builder(innermost_loop);

--- a/lib/TaskflowDialect/Transforms/Optimizations/AffineLoopPerfectionPass.cpp
+++ b/lib/TaskflowDialect/Transforms/Optimizations/AffineLoopPerfectionPass.cpp
@@ -57,9 +57,69 @@ static bool hasSideEffect(Operation *op) {
   return true;
 }
 
-static bool usesLoopResult(Operation *op, affine::AffineForOp loop) {
-  return llvm::any_of(op->getOperands(), [&](Value operand) {
-    return llvm::is_contained(loop.getResults(), operand);
+static Value
+resolveLoopResultToYieldOperand(Value value,
+                                ArrayRef<affine::AffineForOp> inner_loops) {
+  // When an epilogue op uses a nested loop result, sinking that op into the
+  // innermost loop would violate dominance.  At the last iteration, the loop
+  // result is exactly the corresponding affine.yield operand, so use that
+  // in-loop value instead.
+  bool changed = true;
+  while (changed) {
+    changed = false;
+
+    for (affine::AffineForOp loop : inner_loops) {
+      auto yield_op =
+          dyn_cast<affine::AffineYieldOp>(loop.getBody()->getTerminator());
+      if (!yield_op) {
+        return nullptr;
+      }
+
+      for (auto [idx, result] : llvm::enumerate(loop.getResults())) {
+        if (value != result) {
+          continue;
+        }
+
+        if (idx >= yield_op.getNumOperands()) {
+          return nullptr;
+        }
+
+        value = yield_op.getOperand(idx);
+        changed = true;
+        break;
+      }
+
+      if (changed) {
+        break;
+      }
+    }
+  }
+
+  return value;
+}
+
+static LogicalResult
+remapLoopResultOperands(Operation *op,
+                        ArrayRef<affine::AffineForOp> inner_loops) {
+  for (OpOperand &operand : op->getOpOperands()) {
+    Value old_value = operand.get();
+    Value new_value = resolveLoopResultToYieldOperand(old_value, inner_loops);
+    if (!new_value) {
+      return failure();
+    }
+
+    if (new_value != old_value) {
+      operand.set(new_value);
+    }
+  }
+
+  return success();
+}
+
+static bool hasResultUsedByOperation(Operation *producer, Operation *user) {
+  return llvm::any_of(producer->getResults(), [&](Value result) {
+    return llvm::any_of(result.getUses(),
+                        [&](OpOperand &use) { return use.getOwner() == user; });
   });
 }
 
@@ -95,10 +155,13 @@ static LogicalResult checkLoopBandSupported(AffineLoopBand &loop_band) {
         return failure();
       }
 
-      if (!is_prologue && usesLoopResult(&op, child_loop)) {
+      if (is_prologue && hasResultUsedByOperation(&op, child_loop)) {
+        // Example: %init = affine.load ...; affine.for ... iter_args(%x =
+        // %init). Moving %init into the child loop would place the definition
+        // after the child loop operand use, so keep this band unchanged.
         llvm::errs()
-            << "[LoopPerfection] Skipping unsupported loop band: epilogue "
-               "operation uses a child loop result.\n";
+            << "[LoopPerfection] Skipping unsupported loop band: prologue "
+               "operation is used by child loop operands.\n";
         return failure();
       }
 
@@ -416,6 +479,11 @@ static LogicalResult applyLoopPerfection(AffineLoopBand &loop_band) {
       // if redundant).
       for (Operation *op : pure_ops) {
         op->moveBefore(insert_point);
+        if (failed(remapLoopResultOperands(op, inner_loops))) {
+          llvm::errs() << "[LoopPerfection] Failed to remap epilogue loop "
+                          "result operand.\n";
+          return failure();
+        }
       }
 
       // Moves side-effecting operations into the innermost loop with
@@ -432,6 +500,11 @@ static LogicalResult applyLoopPerfection(AffineLoopBand &loop_band) {
 
           for (Operation *op : side_effect_ops) {
             op->moveBefore(then_block->getTerminator());
+            if (failed(remapLoopResultOperands(op, inner_loops))) {
+              llvm::errs() << "[LoopPerfection] Failed to remap epilogue loop "
+                              "result operand.\n";
+              return failure();
+            }
           }
         } else {
           // If condition creation fails, returns failure to avoid

--- a/lib/TaskflowDialect/Transforms/Optimizations/AffineLoopTreeSerializationPass.cpp
+++ b/lib/TaskflowDialect/Transforms/Optimizations/AffineLoopTreeSerializationPass.cpp
@@ -171,15 +171,58 @@ public:
 
   // Entry point for building one MCT. `buildNode` does the recursive work while
   // this function owns the old-to-new value mapping for the whole chain.
-  affine::AffineForOp build(const LoopChain &chain) {
+  FailureOr<affine::AffineForOp> build(const LoopChain &chain) {
     // Mapping from old values to new values.
     IRMapping mapping;
-    return buildNode(chain, /*index=*/0, mapping, builder);
+    return buildNode(chain, /*index=*/0, mapping, builder,
+                     chain.getRoot()->loop_op.getOperation());
   }
 
 private:
   OpBuilder &builder;
   Location loc;
+
+  static bool isDefinedInside(Operation *root_op, Value value) {
+    if (auto block_arg = dyn_cast<BlockArgument>(value)) {
+      Region *region = block_arg.getParentRegion();
+      Operation *owner = region ? region->getParentOp() : nullptr;
+      while (owner) {
+        if (owner == root_op) {
+          return true;
+        }
+        owner = owner->getParentOp();
+      }
+      return false;
+    }
+
+    Operation *def = value.getDefiningOp();
+    while (def) {
+      if (def == root_op) {
+        return true;
+      }
+      def = def->getParentOp();
+    }
+    return false;
+  }
+
+  LogicalResult checkOperandsMapped(Operation *op, Operation *root_op,
+                                    const IRMapping &mapping) {
+    for (Value operand : op->getOperands()) {
+      if (isDefinedInside(root_op, operand) && !mapping.contains(operand)) {
+        return failure();
+      }
+    }
+    return success();
+  }
+
+  FailureOr<Value> lookupMappedValue(Operation *op, Value value,
+                                     Operation *root_op,
+                                     const IRMapping &mapping) {
+    if (isDefinedInside(root_op, value) && !mapping.contains(value)) {
+      return failure();
+    }
+    return mapping.lookupOrDefault(value);
+  }
 
   // Recursively rebuilds `chain[index]` and its selected child.
   //
@@ -191,8 +234,10 @@ private:
   //
   // Rebuilding the selected child exactly where it appeared ensures `%sum` is
   // mapped before later operations are cloned.
-  affine::AffineForOp buildNode(const LoopChain &chain, size_t index,
-                                IRMapping &mapping, OpBuilder &insert_builder) {
+  FailureOr<affine::AffineForOp> buildNode(const LoopChain &chain, size_t index,
+                                           IRMapping &mapping,
+                                           OpBuilder &insert_builder,
+                                           Operation *root_op) {
     SALTNode *node = chain.nodes[index];
     // The next node in the LoopChain is the only nested loop cloned at this
     // level. Other sibling loops are serialized into their own MCTs.
@@ -201,7 +246,12 @@ private:
 
     SmallVector<Value> iter_args_init_values;
     for (Value init : node->loop_op.getInits()) {
-      iter_args_init_values.push_back(mapping.lookupOrDefault(init));
+      FailureOr<Value> mapped_init =
+          lookupMappedValue(node->loop_op, init, root_op, mapping);
+      if (failed(mapped_init)) {
+        return failure();
+      }
+      iter_args_init_values.push_back(*mapped_init);
     }
 
     auto new_loop = insert_builder.create<affine::AffineForOp>(
@@ -234,7 +284,13 @@ private:
       if (auto yield_op = dyn_cast<affine::AffineYieldOp>(&op)) {
         SmallVector<Value> yielded_values;
         for (Value operand : yield_op.getOperands()) {
-          yielded_values.push_back(mapping.lookupOrDefault(operand));
+          FailureOr<Value> mapped_operand =
+              lookupMappedValue(yield_op, operand, root_op, mapping);
+          if (failed(mapped_operand)) {
+            new_loop.erase();
+            return failure();
+          }
+          yielded_values.push_back(*mapped_operand);
         }
         body_builder.create<affine::AffineYieldOp>(loc, yielded_values);
         continue;
@@ -243,7 +299,11 @@ private:
       if (auto nested_for = dyn_cast<affine::AffineForOp>(&op)) {
         // Only clone the selected child for this root-to-leaf chain.
         if (selected_child && nested_for == selected_child->loop_op) {
-          buildNode(chain, index + 1, mapping, body_builder);
+          if (failed(buildNode(chain, index + 1, mapping, body_builder,
+                               root_op))) {
+            new_loop.erase();
+            return failure();
+          }
           body_builder = OpBuilder::atBlockEnd(body);
         }
         continue;
@@ -251,6 +311,10 @@ private:
 
       // Non-loop operations belong to this MCT and are cloned with the current
       // mapping. Their results are then available to later operations.
+      if (failed(checkOperandsMapped(&op, root_op, mapping))) {
+        new_loop.erase();
+        return failure();
+      }
       Operation *new_op = body_builder.clone(op, mapping);
       for (auto [old_res, new_res] :
            llvm::zip(op.getResults(), new_op->getResults())) {
@@ -346,22 +410,36 @@ private:
       }
 
       // Builds new chains.
+      bool serialized_root = true;
+      SmallVector<affine::AffineForOp> new_loops;
       for (const LoopChain &chain : root_chains) {
         MCTBuilder mct_builder(builder, loc);
-        affine::AffineForOp new_loop = mct_builder.build(chain);
-
-        // If the original root loop had results (iter_args), and the new loop
-        // has matching results, we must replace the uses of the original
-        // results with the new ones. NOTE: This assumes that for a loop
-        // defining values, there is a corresponding single chain that produces
-        // all the values (or at least the one we process). If a root with
-        // results is split into multiple chains, this simple logic might loop
-        // over them. However, for a reduction loop that is a single chain, this
-        // works.
-        if (root->loop_op.getNumResults() > 0 && new_loop &&
-            new_loop.getNumResults() == root->loop_op.getNumResults()) {
-          root->loop_op.replaceAllUsesWith(new_loop.getResults());
+        FailureOr<affine::AffineForOp> new_loop = mct_builder.build(chain);
+        if (failed(new_loop)) {
+          serialized_root = false;
+          break;
         }
+        new_loops.push_back(*new_loop);
+      }
+
+      if (!serialized_root) {
+        for (auto it = new_loops.rbegin(); it != new_loops.rend(); ++it) {
+          it->erase();
+        }
+        continue;
+      }
+
+      // If the original root loop had results (iter_args), and the new loop
+      // has matching results, we must replace the uses of the original
+      // results with the new ones. NOTE: This assumes that for a loop
+      // defining values, there is a corresponding single chain that produces
+      // all the values (or at least the one we process). If a root with
+      // results is split into multiple chains, this simple logic might loop
+      // over them. However, for a reduction loop that is a single chain, this
+      // works.
+      if (root->loop_op.getNumResults() > 0 && new_loops.size() == 1 &&
+          new_loops.front().getNumResults() == root->loop_op.getNumResults()) {
+        root->loop_op.replaceAllUsesWith(new_loops.front().getResults());
       }
 
       // Erases the original root loop.

--- a/lib/TaskflowDialect/Transforms/Optimizations/AffineLoopTreeSerializationPass.cpp
+++ b/lib/TaskflowDialect/Transforms/Optimizations/AffineLoopTreeSerializationPass.cpp
@@ -158,153 +158,108 @@ private:
 };
 
 //==============================================================================
-// MCT Builder - Builds nested affine.for loops for the entire chain.
+// MCT Builder.
+//
+// MCT stands for "Minimized Canonicalized Task": a standalone affine loop nest
+// rebuilt from one root-to-leaf LoopChain extracted from the original SALT. If
+// a loop tree has multiple leaf loops, this pass serializes it into multiple
+// MCTs, one per root-to-leaf path.
 //==============================================================================
 class MCTBuilder {
 public:
   MCTBuilder(OpBuilder &builder, Location loc) : builder(builder), loc(loc) {}
 
-  // Builds the loop chain and returns the outermost loop.
-  // The built loops will be inserted at the builder's current insertion point.
+  // Entry point for building one MCT. `buildNode` does the recursive work while
+  // this function owns the old-to-new value mapping for the whole chain.
   affine::AffineForOp build(const LoopChain &chain) {
     // Mapping from old values to new values.
     IRMapping mapping;
-
-    affine::AffineForOp outer_loop = nullptr;
-    Block *current_insert_block = nullptr;
-    SmallVector<affine::AffineForOp> created_loops;
-
-    // Iterate from root to leaf to build the nested loops.
-    for (size_t i = 0; i < chain.nodes.size(); ++i) {
-      SALTNode *node = chain.nodes[i];
-      bool is_first = (i == 0);
-
-      OpBuilder loop_builder(builder.getContext());
-      if (is_first) {
-        loop_builder = builder;
-      } else {
-        // We want to insert the nested loop at the end of the current block.
-        // If the block has a terminator (e.g. yield we just added/cloned?),
-        // we should insert before it?
-        // Actually, we remove default yield immediately after creation.
-        // So the block usually doesn't have a terminator when we are filling
-        // it, UNLESS we cloned a yield from body ops? SALT excludes Yields from
-        // body_operations. So current_insert_block should be terminator-free
-        // (or we removed it).
-        loop_builder = OpBuilder::atBlockEnd(current_insert_block);
-      }
-
-      // Prepares iter_args for the new loop.
-      SmallVector<Value> iter_args_init_values;
-      if (node->loop_op.getNumIterOperands() > 0) {
-        for (Value init : node->loop_op.getInits()) {
-          iter_args_init_values.push_back(mapping.lookupOrDefault(init));
-        }
-      }
-
-      // Creates new loop with same bounds and iter_args.
-      auto new_loop = loop_builder.create<affine::AffineForOp>(
-          loc, node->lower_bound, node->upper_bound, node->step,
-          iter_args_init_values);
-
-      created_loops.push_back(new_loop);
-
-      // Maps the old induction variable to the new one.
-      mapping.map(node->loop_op.getInductionVar(), new_loop.getInductionVar());
-
-      // Maps the old iter_args (block args) to the new iter_args (block args).
-      if (node->loop_op.getNumRegionIterArgs() > 0) {
-        for (auto [old_arg, new_arg] :
-             llvm::zip(node->loop_op.getRegionIterArgs(),
-                       new_loop.getRegionIterArgs())) {
-          mapping.map(old_arg, new_arg);
-        }
-      }
-
-      if (is_first) {
-        outer_loop = new_loop;
-      }
-
-      // Updates current insertion block to the body of the new loop.
-      current_insert_block = new_loop.getBody();
-
-      // Removes the default yield created by create<AffineForOp>.
-      if (!current_insert_block->empty() &&
-          isa<affine::AffineYieldOp>(current_insert_block->back()))
-        current_insert_block->back().erase();
-
-      // Clones body operations for THIS node.
-      OpBuilder body_builder = OpBuilder::atBlockEnd(current_insert_block);
-      for (Operation *op : node->body_operations) {
-        Operation *new_op = body_builder.clone(*op, mapping);
-        // Updates mapping with results of the new op.
-        for (auto [old_res, new_res] :
-             llvm::zip(op->getResults(), new_op->getResults())) {
-          mapping.map(old_res, new_res);
-        }
-      }
-    }
-
-    // Fixes up yields for non-leaf loops (bottom-up).
-    for (int i = created_loops.size() - 2; i >= 0; --i) {
-      affine::AffineForOp parent = created_loops[i];
-      affine::AffineForOp child = created_loops[i + 1];
-
-      OpBuilder yield_builder = OpBuilder::atBlockEnd(parent.getBody());
-
-      if (child.getNumResults() > 0) {
-        yield_builder.create<affine::AffineYieldOp>(loc, child.getResults());
-      } else {
-        yield_builder.create<affine::AffineYieldOp>(loc);
-      }
-    }
-
-    // For the LEAF loop, we cloned body operations (which excludes Yields).
-    // So the leaf loop likely has NO yield now.
-    // We must add a yield to the leaf loop that yields the results of the
-    // operations that produced results (mapped from original yield).
-    // SALTNode loop_op is the original loop.
-    // The original loop body had a yield.
-    // We need to find what the original yield yielded, map it, and yield it
-    // here.
-
-    // If SALT excludes Yield from body_operations, then we NEVER cloned
-    // the yield. So the leaf loop has no terminator. We must reconstruct the
-    // yield for the leaf loop.
-
-    if (!created_loops.empty()) {
-      affine::AffineForOp new_leaf = created_loops.back();
-      SALTNode *leaf_node = chain.getLeaf(); // or chain.nodes.back()
-
-      // Finds the yield op in the original leaf node.
-      Operation *original_yield = nullptr;
-      for (Operation &op : leaf_node->loop_op.getBody()->getOperations()) {
-        if (isa<affine::AffineYieldOp>(&op)) {
-          original_yield = &op;
-          break;
-        }
-      }
-
-      if (original_yield) {
-        OpBuilder leaf_yield_builder =
-            OpBuilder::atBlockEnd(new_leaf.getBody());
-        SmallVector<Value> yielded_values;
-        for (Value operand : original_yield->getOperands()) {
-          yielded_values.push_back(mapping.lookupOrDefault(operand));
-        }
-        leaf_yield_builder.create<affine::AffineYieldOp>(loc, yielded_values);
-      } else {
-        assert(false &&
-               "Original leaf loop must have a yield operation in its body.");
-      }
-    }
-
-    return outer_loop;
+    return buildNode(chain, /*index=*/0, mapping, builder);
   }
 
 private:
   OpBuilder &builder;
   Location loc;
+
+  // Recursively rebuilds `chain[index]` and its selected child.
+  //
+  // The original loop body order matters. A parent loop body may contain a
+  // child reduction followed by an operation that consumes the child result:
+  //
+  //   %sum = affine.for ... -> f32 { ... }
+  //   affine.store %sum, ...
+  //
+  // Rebuilding the selected child exactly where it appeared ensures `%sum` is
+  // mapped before later operations are cloned.
+  affine::AffineForOp buildNode(const LoopChain &chain, size_t index,
+                                IRMapping &mapping, OpBuilder &insert_builder) {
+    SALTNode *node = chain.nodes[index];
+    // The next node in the LoopChain is the only nested loop cloned at this
+    // level. Other sibling loops are serialized into their own MCTs.
+    SALTNode *selected_child =
+        (index + 1 < chain.nodes.size()) ? chain.nodes[index + 1] : nullptr;
+
+    SmallVector<Value> iter_args_init_values;
+    for (Value init : node->loop_op.getInits()) {
+      iter_args_init_values.push_back(mapping.lookupOrDefault(init));
+    }
+
+    auto new_loop = insert_builder.create<affine::AffineForOp>(
+        loc, node->lower_bound, node->upper_bound, node->step,
+        iter_args_init_values);
+
+    mapping.map(node->loop_op.getInductionVar(), new_loop.getInductionVar());
+
+    for (auto [old_arg, new_arg] : llvm::zip(node->loop_op.getRegionIterArgs(),
+                                             new_loop.getRegionIterArgs())) {
+      mapping.map(old_arg, new_arg);
+    }
+
+    for (auto [old_result, new_result] :
+         llvm::zip(node->loop_op.getResults(), new_loop.getResults())) {
+      mapping.map(old_result, new_result);
+    }
+
+    Block *body = new_loop.getBody();
+    if (!body->empty() && isa<affine::AffineYieldOp>(body->back())) {
+      body->back().erase();
+    }
+
+    // Clone the body in source order. This is what keeps child-loop results
+    // available before cloning later non-loop operations that consume them.
+    OpBuilder body_builder = OpBuilder::atBlockEnd(body);
+
+    for (Operation &op : node->loop_op.getBody()->getOperations()) {
+      // Rebuild yields explicitly because the default yield was removed above.
+      if (auto yield_op = dyn_cast<affine::AffineYieldOp>(&op)) {
+        SmallVector<Value> yielded_values;
+        for (Value operand : yield_op.getOperands()) {
+          yielded_values.push_back(mapping.lookupOrDefault(operand));
+        }
+        body_builder.create<affine::AffineYieldOp>(loc, yielded_values);
+        continue;
+      }
+
+      if (auto nested_for = dyn_cast<affine::AffineForOp>(&op)) {
+        // Only clone the selected child for this root-to-leaf chain.
+        if (selected_child && nested_for == selected_child->loop_op) {
+          buildNode(chain, index + 1, mapping, body_builder);
+          body_builder = OpBuilder::atBlockEnd(body);
+        }
+        continue;
+      }
+
+      // Non-loop operations belong to this MCT and are cloned with the current
+      // mapping. Their results are then available to later operations.
+      Operation *new_op = body_builder.clone(op, mapping);
+      for (auto [old_res, new_res] :
+           llvm::zip(op.getResults(), new_op->getResults())) {
+        mapping.map(old_res, new_res);
+      }
+    }
+
+    return new_loop;
+  }
 };
 
 //==============================================================================

--- a/test/multi-cgra/taskflow/attention/attention.mlir
+++ b/test/multi-cgra/taskflow/attention/attention.mlir
@@ -1,0 +1,136 @@
+// RUN: mlir-neura-opt %s --affine-loop-tree-serialization \
+// RUN: --affine-loop-perfection \
+// RUN: -o %t.perfect.mlir
+// RUN: FileCheck %s --input-file=%t.perfect.mlir --check-prefixes=PERFECT
+
+module attributes {} {
+  func.func @_Z18attention_pipelinePKfS0_S0_S0_PfS1_S1_S1_S1_S1_(%arg0: memref<?xf32>, %arg1: memref<?xf32>, %arg2: memref<?xf32>, %arg3: memref<?xf32>, %arg4: memref<?xf32>, %arg5: memref<?xf32>, %arg6: memref<?xf32>, %arg7: memref<?xf32>, %arg8: memref<?xf32>, %arg9: memref<?xf32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+    %cst = arith.constant 9.99999974E-5 : f32
+    %cst_0 = arith.constant 0.166666672 : f32
+    %cst_1 = arith.constant 5.000000e-01 : f32
+    %cst_2 = arith.constant 1.000000e+00 : f32
+    %cst_3 = arith.constant 1.250000e-01 : f32
+    %cst_4 = arith.constant 0.000000e+00 : f32
+    %alloca = memref.alloca() : memref<256xf32>
+    %alloca_5 = memref.alloca() : memref<256xf32>
+    affine.for %arg10 = 0 to 256 {
+      affine.for %arg11 = 0 to 64 {
+        %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
+          %1 = affine.load %arg0[%arg12 + %arg10 * 64] : memref<?xf32>
+          %2 = affine.load %arg1[%arg11 + %arg12 * 64] : memref<?xf32>
+          %3 = arith.mulf %1, %2 : f32
+          %4 = arith.addf %arg13, %3 : f32
+          affine.yield %4 : f32
+        }
+        affine.store %0, %arg4[%arg11 + %arg10 * 64] : memref<?xf32>
+      }
+    }
+    affine.for %arg10 = 0 to 256 {
+      affine.for %arg11 = 0 to 64 {
+        %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
+          %1 = affine.load %arg0[%arg12 + %arg10 * 64] : memref<?xf32>
+          %2 = affine.load %arg2[%arg11 + %arg12 * 64] : memref<?xf32>
+          %3 = arith.mulf %1, %2 : f32
+          %4 = arith.addf %arg13, %3 : f32
+          affine.yield %4 : f32
+        }
+        affine.store %0, %arg5[%arg11 + %arg10 * 64] : memref<?xf32>
+      }
+    }
+    affine.for %arg10 = 0 to 256 {
+      affine.for %arg11 = 0 to 64 {
+        %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
+          %1 = affine.load %arg0[%arg12 + %arg10 * 64] : memref<?xf32>
+          %2 = affine.load %arg3[%arg11 + %arg12 * 64] : memref<?xf32>
+          %3 = arith.mulf %1, %2 : f32
+          %4 = arith.addf %arg13, %3 : f32
+          affine.yield %4 : f32
+        }
+        affine.store %0, %arg6[%arg11 + %arg10 * 64] : memref<?xf32>
+      }
+    }
+    affine.for %arg10 = 0 to 256 {
+      affine.for %arg11 = 0 to 256 {
+        %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
+          %2 = affine.load %arg4[%arg12 + %arg10 * 64] : memref<?xf32>
+          %3 = affine.load %arg5[%arg12 + %arg11 * 64] : memref<?xf32>
+          %4 = arith.mulf %2, %3 : f32
+          %5 = arith.addf %arg13, %4 : f32
+          affine.yield %5 : f32
+        }
+        %1 = arith.mulf %0, %cst_3 : f32
+        affine.store %1, %arg7[%arg11 + %arg10 * 256] : memref<?xf32>
+      }
+    }
+    affine.for %arg10 = 0 to 256 {
+      %0 = affine.load %arg7[%arg10 * 256] : memref<?xf32>
+      %1 = affine.for %arg11 = 1 to 256 iter_args(%arg12 = %0) -> (f32) {
+        %2 = affine.load %arg7[%arg11 + %arg10 * 256] : memref<?xf32>
+        %3 = arith.cmpf ogt, %2, %arg12 : f32
+        %4 = arith.select %3, %2, %arg12 : f32
+        affine.yield %4 : f32
+      }
+      affine.store %1, %alloca_5[%arg10] : memref<256xf32>
+    }
+    affine.for %arg10 = 0 to 256 {
+      %0 = affine.load %alloca_5[%arg10] : memref<256xf32>
+      %1 = affine.for %arg11 = 0 to 256 iter_args(%arg12 = %cst_4) -> (f32) {
+        %2 = affine.load %arg7[%arg11 + %arg10 * 256] : memref<?xf32>
+        %3 = arith.subf %2, %0 : f32
+        %4 = arith.mulf %3, %3 : f32
+        %5 = arith.mulf %4, %3 : f32
+        %6 = arith.addf %3, %cst_2 : f32
+        %7 = arith.mulf %4, %cst_1 : f32
+        %8 = arith.addf %6, %7 : f32
+        %9 = arith.mulf %5, %cst_0 : f32
+        %10 = arith.addf %8, %9 : f32
+        %11 = arith.cmpf olt, %10, %cst : f32
+        %12 = arith.select %11, %cst, %10 : f32
+        affine.store %12, %arg8[%arg11 + %arg10 * 256] : memref<?xf32>
+        %13 = arith.addf %arg12, %12 : f32
+        affine.yield %13 : f32
+      }
+      affine.store %1, %alloca[%arg10] : memref<256xf32>
+    }
+    affine.for %arg10 = 0 to 256 {
+      %0 = affine.load %alloca[%arg10] : memref<256xf32>
+      affine.for %arg11 = 0 to 256 {
+        %1 = affine.load %arg8[%arg11 + %arg10 * 256] : memref<?xf32>
+        %2 = arith.divf %1, %0 : f32
+        affine.store %2, %arg8[%arg11 + %arg10 * 256] : memref<?xf32>
+      }
+    }
+    affine.for %arg10 = 0 to 256 {
+      affine.for %arg11 = 0 to 64 {
+        %0 = affine.for %arg12 = 0 to 256 iter_args(%arg13 = %cst_4) -> (f32) {
+          %1 = affine.load %arg8[%arg12 + %arg10 * 256] : memref<?xf32>
+          %2 = affine.load %arg6[%arg11 + %arg12 * 64] : memref<?xf32>
+          %3 = arith.mulf %1, %2 : f32
+          %4 = arith.addf %arg13, %3 : f32
+          affine.yield %4 : f32
+        }
+        affine.store %0, %arg9[%arg11 + %arg10 * 64] : memref<?xf32>
+      }
+    }
+    return
+  }
+}
+
+// PERFECT:        affine.for %arg10 = 0 to 256 {
+// PERFECT-NEXT:      affine.for %arg11 = 0 to 64 {
+// PERFECT-NEXT:        %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
+// PERFECT-NEXT:          %1 = affine.load %arg0[%arg12 + %arg10 * 64] : memref<?xf32>
+// PERFECT-NEXT:          %2 = affine.load %arg1[%arg11 + %arg12 * 64] : memref<?xf32>
+// PERFECT-NEXT:          %3 = arith.mulf %1, %2 : f32
+// PERFECT-NEXT:          %4 = arith.addf %arg13, %3 : f32
+// PERFECT-NEXT:          %c1 = arith.constant 1 : index
+// PERFECT-NEXT:          %5 = arith.addi %arg12, %c1 : index
+// PERFECT-NEXT:          %c64 = arith.constant 64 : index
+// PERFECT-NEXT:          %6 = arith.cmpi sge, %5, %c64 : index
+// PERFECT-NEXT:          scf.if %6 {
+// PERFECT-NEXT:           affine.store %4, %arg4[%arg11 + %arg10 * 64] : memref<?xf32>
+// PERFECT-NEXT:          }
+// PERFECT-NEXT:          affine.yield %4 : f32
+// PERFECT-NEXT:        }
+// PERFECT-NEXT:      }
+// PERFECT-NEXT:    }

--- a/test/multi-cgra/taskflow/attention/attention.mlir
+++ b/test/multi-cgra/taskflow/attention/attention.mlir
@@ -90,6 +90,10 @@ module attributes {} {
       }
       affine.store %1, %alloca_5[%arg10] : memref<256xf32>
     }
+    // Softmax uses a third-order Taylor approximation for exp(x), not a math.exp
+    // op: exp(x) ~= 1 + x + 0.5*x^2 + (1/6)*x^3. The input is shifted by the
+    // row maximum for numerical stability, clamped to 1e-4, stored as the
+    // unnormalized probability, and accumulated into the row denominator.
     affine.for %arg10 = 0 to 256 {
       %0 = affine.load %alloca_5[%arg10] : memref<256xf32>
       %1 = affine.for %arg11 = 0 to 256 iter_args(%arg12 = %cst_4) -> (f32) {
@@ -110,6 +114,7 @@ module attributes {} {
       }
       affine.store %1, %alloca[%arg10] : memref<256xf32>
     }
+    // Normalize the Taylor-approximated softmax values by the row denominator.
     affine.for %arg10 = 0 to 256 {
       %0 = affine.load %alloca[%arg10] : memref<256xf32>
       affine.for %arg11 = 0 to 256 {

--- a/test/multi-cgra/taskflow/attention/attention.mlir
+++ b/test/multi-cgra/taskflow/attention/attention.mlir
@@ -13,6 +13,24 @@ module attributes {} {
     %cst_4 = arith.constant 0.000000e+00 : f32
     %alloca = memref.alloca() : memref<256xf32>
     %alloca_5 = memref.alloca() : memref<256xf32>
+    // PERFECT:        affine.for %arg10 = 0 to 256 {
+    // PERFECT-NEXT:      affine.for %arg11 = 0 to 64 {
+    // PERFECT-NEXT:        %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
+    // PERFECT-NEXT:          %1 = affine.load %arg0[%arg12 + %arg10 * 64] : memref<?xf32>
+    // PERFECT-NEXT:          %2 = affine.load %arg1[%arg11 + %arg12 * 64] : memref<?xf32>
+    // PERFECT-NEXT:          %3 = arith.mulf %1, %2 : f32
+    // PERFECT-NEXT:          %4 = arith.addf %arg13, %3 : f32
+    // PERFECT-NEXT:          %c1 = arith.constant 1 : index
+    // PERFECT-NEXT:          %5 = arith.addi %arg12, %c1 : index
+    // PERFECT-NEXT:          %c64 = arith.constant 64 : index
+    // PERFECT-NEXT:          %6 = arith.cmpi sge, %5, %c64 : index
+    // PERFECT-NEXT:          scf.if %6 {
+    // PERFECT-NEXT:           affine.store %4, %arg4[%arg11 + %arg10 * 64] : memref<?xf32>
+    // PERFECT-NEXT:          }
+    // PERFECT-NEXT:          affine.yield %4 : f32
+    // PERFECT-NEXT:        }
+    // PERFECT-NEXT:      }
+    // PERFECT-NEXT:    }
     affine.for %arg10 = 0 to 256 {
       affine.for %arg11 = 0 to 64 {
         %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
@@ -115,22 +133,3 @@ module attributes {} {
     return
   }
 }
-
-// PERFECT:        affine.for %arg10 = 0 to 256 {
-// PERFECT-NEXT:      affine.for %arg11 = 0 to 64 {
-// PERFECT-NEXT:        %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
-// PERFECT-NEXT:          %1 = affine.load %arg0[%arg12 + %arg10 * 64] : memref<?xf32>
-// PERFECT-NEXT:          %2 = affine.load %arg1[%arg11 + %arg12 * 64] : memref<?xf32>
-// PERFECT-NEXT:          %3 = arith.mulf %1, %2 : f32
-// PERFECT-NEXT:          %4 = arith.addf %arg13, %3 : f32
-// PERFECT-NEXT:          %c1 = arith.constant 1 : index
-// PERFECT-NEXT:          %5 = arith.addi %arg12, %c1 : index
-// PERFECT-NEXT:          %c64 = arith.constant 64 : index
-// PERFECT-NEXT:          %6 = arith.cmpi sge, %5, %c64 : index
-// PERFECT-NEXT:          scf.if %6 {
-// PERFECT-NEXT:           affine.store %4, %arg4[%arg11 + %arg10 * 64] : memref<?xf32>
-// PERFECT-NEXT:          }
-// PERFECT-NEXT:          affine.yield %4 : f32
-// PERFECT-NEXT:        }
-// PERFECT-NEXT:      }
-// PERFECT-NEXT:    }


### PR DESCRIPTION
In the previous affine loop perfection pass, we are not able to handle the case like:

```mlir
    affine.for %arg10 = 0 to 256 {
      affine.for %arg11 = 0 to 64 {
        %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
          %1 = affine.load %arg0[%arg12 + %arg10 * 64] : memref<?xf32>
          %2 = affine.load %arg1[%arg11 + %arg12 * 64] : memref<?xf32>
          %3 = arith.mulf %1, %2 : f32
          %4 = arith.addf %arg13, %3 : f32
          affine.yield %4 : f32
        }
        affine.store %0, %arg4[%arg11 + %arg10 * 64] : memref<?xf32>
      }
    }
```
where there are both `iter_args` and epilogue after the loop.

We enhance the code logic to transform such case into 
```mlir
    affine.for %arg10 = 0 to 256 {
      affine.for %arg11 = 0 to 64 {
        %0 = affine.for %arg12 = 0 to 64 iter_args(%arg13 = %cst_4) -> (f32) {
          %1 = affine.load %arg0[%arg12 + %arg10 * 64] : memref<?xf32>
          %2 = affine.load %arg1[%arg11 + %arg12 * 64] : memref<?xf32>
          %3 = arith.mulf %1, %2 : f32
          %4 = arith.addf %arg13, %3 : f32
          %c1 = arith.constant 1 : index
          %5 = arith.addi %arg12, %c1 : index
          %c64 = arith.constant 64 : index
          %6 = arith.cmpi sge, %5, %c64 : index
          scf.if %6 {
            affine.store %4, %arg4[%arg11 + %arg10 * 64] : memref<?xf32>
          }
          affine.yield %4 : f32
        }
      }
    }
```