### PR TITLE
Refine Taskflow Memory Dependency Semantics

### DIFF
--- a/include/TaskflowDialect/TaskflowOps.td
+++ b/include/TaskflowDialect/TaskflowOps.td
@@ -31,23 +31,27 @@ def TaskflowTaskOp
   let summary = "Computation task operation within a Taskflow graph.";
 
   let description = [{
-    Represents a computational task that takes data inputs and produces
-    data outoputs. Tasks are isolated from their surrounding scope and can only
-    communicate through explicit data dependencies.
+    Represents a computational task that consumes and produces explicit
+    dependence-state SSA values. Tasks are isolated from their surrounding scope
+    and can only communicate through these explicit dependencies.
 
     Tasks has two types of inputs/outputs:
-    1. Memory dependencies: memrefs that are read or written by the task
+    1. Memory dependence states: memref SSA versions that the task reads or
+       writes. A dependency_read_out or dependency_write_out is still the same
+       underlying memref, but represents the state after this task has observed
+       or modified it.
     2. Value dependencies: SSA values from producer tasks
 
-    The `original_read_memrefs` and `original_write_memrefs` attributes record the actural
-    original memrefs that this task accesses,
-    enabling data placement analysis for multi-CGRA mapping.
+    The `original_read_memrefs` and `original_write_memrefs` operands record
+    the actual original memrefs that this task accesses. These operands keep
+    the memory identity separate from the dependence-state SSA value, enabling
+    dependence analysis and data placement for multi-CGRA mapping.
 
     Example:
-      // Memory inputs: %mem, Value inputs: %val
+      // Memory state inputs: %mem_state, %out_state. Value input: %val.
       $out_mem, %out_val = taskflow.task "Task_0"
-        dependency_read_in(%mem : memref<4xi32>)
-        dependency_write_in(%arg5 : memref<?xi32>)
+        dependency_read_in(%mem_state : memref<4xi32>)
+        dependency_write_in(%out_state : memref<?xi32>)
         value_inputs(%val : i32)
         [original_read_memrefs(%arg0 : memref<?x8x6xi32>),
          original_write_memrefs(%arg5 : memref<?xi32>)] {
@@ -82,8 +86,10 @@ def TaskflowYieldOp
                                ParentOneOf<["TaskflowTaskOp"]>]> {
   let summary = "Yield operation for Taskflow task";
   let description = [{
-    Yields values from a task body. The number and types of operands
-    must match the result types of the parent taskflow.task operation.
+    Yields dependence-state and value results from a task body. Read results
+    are sparse: a task only needs to yield a read state when a later writer must
+    depend on that read for WAR ordering. The number and types of operands must
+    match the result types of the parent taskflow.task operation.
     
     Example:
       taskflow.task "Task_0" (%arg0, %arg1) {

--- a/lib/Conversion/AffineToTaskflow/AffineToTaskflowPass.cpp
+++ b/lib/Conversion/AffineToTaskflow/AffineToTaskflowPass.cpp
@@ -91,12 +91,22 @@ static void collectExternalValues(Operation *root_op,
   }
 }
 
-// Updates operands of an operation using the value mapping.
+// Updates operands of a non-loop operation after preceding loops have been
+// converted into taskflow.task ops. Memref operands consume the latest write
+// state for that original memref; scalar SSA values use value_mapping.
 static void
 updateOperationOperands(Operation *op,
+                        const DenseMap<Value, Value> &latest_write_out,
                         const DenseMap<Value, Value> &value_mapping) {
   for (OpOperand &operand : op->getOpOperands()) {
     Value original_value = operand.get();
+    if (isa<MemRefType>(original_value.getType())) {
+      auto it = latest_write_out.find(original_value);
+      if (it != latest_write_out.end())
+        operand.set(it->second);
+      continue;
+    }
+
     auto it = value_mapping.find(original_value);
     if (it != value_mapping.end()) {
       operand.set(it->second);
@@ -136,9 +146,11 @@ analyzeMemrefAccesses(func::FuncOp func_op) {
 // Converts a top-level affine.for to a taskflow.task operation.
 static TaskflowTaskOp convertLoopToTask(
     OpBuilder &builder, affine::AffineForOp for_op,
+    DenseMap<Value, Value> &latest_write_out,
+    DenseMap<Value, SmallVector<Value>> &pending_read_outs,
     DenseMap<Value, Value> &value_mapping,
     const DenseMap<Operation *, MemrefAccessInfo> &loop_to_original_memref_info,
-    int task_id) {
+    const SetVector<Value> &read_output_memrefs, int task_id) {
   Location loc = for_op.getLoc();
   std::string task_name = "Task_" + std::to_string(task_id);
 
@@ -197,12 +209,16 @@ static TaskflowTaskOp convertLoopToTask(
   //-------------------------------------------------------------------
   SmallVector<Value> read_inputs;
   SmallVector<Value> write_inputs;
+  SmallVector<Value> write_input_states;
+  SmallVector<Value> write_body_state_memrefs;
   SmallVector<Value> value_inputs;
   IRMapping mapping;
 
-  // Resolves read inputs.
+  // Resolves read inputs from the latest write state only. Read outputs from
+  // previous readers are pending WAR dependencies for future writers and must
+  // not serialize independent readers.
   for (Value memref : read_memrefs) {
-    Value resolved_memref = value_mapping.lookup(memref);
+    Value resolved_memref = latest_write_out.lookup(memref);
     if (!resolved_memref) {
       resolved_memref = memref;
     }
@@ -210,14 +226,27 @@ static TaskflowTaskOp convertLoopToTask(
     mapping.map(memref, resolved_memref);
   }
 
-  // Resolves write inputs.
+  // Resolves write inputs. A writer must consume all pending read states for
+  // the same original memref before it writes, then it consumes the latest
+  // write state if there is no pending read state. This keeps WAR ordering in
+  // the memref dependence-state chain without introducing read-read edges.
   for (Value memref : write_memrefs) {
-    Value resolved_memref = value_mapping.lookup(memref);
-    if (!resolved_memref) {
-      resolved_memref = memref;
+    auto pending_it = pending_read_outs.find(memref);
+    if (pending_it != pending_read_outs.end() && !pending_it->second.empty()) {
+      for (Value pending_read : pending_it->second) {
+        write_inputs.push_back(pending_read);
+        write_input_states.push_back(pending_read);
+      }
+      write_body_state_memrefs.push_back(pending_it->second.back());
+    } else {
+      Value resolved_memref = latest_write_out.lookup(memref);
+      if (!resolved_memref) {
+        resolved_memref = memref;
+      }
+      write_inputs.push_back(resolved_memref);
+      write_input_states.push_back(resolved_memref);
+      write_body_state_memrefs.push_back(resolved_memref);
     }
-    write_inputs.push_back(resolved_memref);
-    mapping.map(memref, resolved_memref);
   }
 
   // Resolves external SSA value inputs.
@@ -233,9 +262,10 @@ static TaskflowTaskOp convertLoopToTask(
   //-------------------------------------------------------------------
   // Step 5: Prepares output types.
   //-------------------------------------------------------------------
-  // Read output types: passthrough read memrefs for WAR dependency tracking.
+  // Read output types: sparse read states for WAR ordering. These are produced
+  // only when a later writer must depend on this task's read.
   SmallVector<Type> read_output_types;
-  for (Value memref : read_memrefs) {
+  for (Value memref : read_output_memrefs) {
     read_output_types.push_back(memref.getType());
   }
 
@@ -279,11 +309,20 @@ static TaskflowTaskOp convertLoopToTask(
     input_to_block_arg[memref] = arg;
   }
 
-  // Memory write input arguments.
-  for (Value memref : write_memrefs) {
-    BlockArgument arg = task_body->addArgument(memref.getType(), loc);
-    mapping.map(memref, arg);
-    input_to_block_arg[memref] = arg;
+  // Memory write input arguments. There can be multiple dependence states for
+  // one original write memref when several previous readers are pending; the
+  // last argument is used inside the task body as the writable memref state.
+  for (Value state_memref : write_input_states) {
+    BlockArgument arg = task_body->addArgument(state_memref.getType(), loc);
+    mapping.map(state_memref, arg);
+    input_to_block_arg[state_memref] = arg;
+  }
+  for (auto [original_memref, state_memref] :
+       llvm::zip(write_memrefs, write_body_state_memrefs)) {
+    auto it = input_to_block_arg.find(state_memref);
+    assert(it != input_to_block_arg.end() && "write state has no block arg");
+    mapping.map(original_memref, it->second);
+    input_to_block_arg[original_memref] = it->second;
   }
 
   // Value input arguments.
@@ -305,8 +344,9 @@ static TaskflowTaskOp convertLoopToTask(
   SmallVector<Value> yield_for_dependency_write_out;
   SmallVector<Value> value_yield_operands;
 
-  // Read yield outputs: passthrough read memref block args for WAR tracking.
-  for (Value memref : read_memrefs) {
+  // Read yield outputs: passthrough only sparse read states needed by later
+  // writers.
+  for (Value memref : read_output_memrefs) {
     if (input_to_block_arg.count(memref)) {
       yield_for_dependency_read_out.push_back(input_to_block_arg[memref]);
     } else {
@@ -335,20 +375,19 @@ static TaskflowTaskOp convertLoopToTask(
   // Step 9 : Updates value mapping with task outputs for subsequent tasks
   // conversion.
   //-------------------------------------------------------------------
-  // Read outputs: establishes WAR dependency chain.
-  // Only update mapping for memrefs not already mapped by a prior write.
+  // Read outputs: pending WAR states for future writers. These do not update
+  // latest_write_out, so later readers of the same memref remain independent.
   for (auto [memref, task_read_output] :
-       llvm::zip(read_memrefs, task_op.getDependencyReadOut())) {
-    if (!value_mapping.count(memref)) {
-      value_mapping[memref] = task_read_output;
-    }
+       llvm::zip(read_output_memrefs, task_op.getDependencyReadOut())) {
+    pending_read_outs[memref].push_back(task_read_output);
   }
 
-  // Memory outputs (write): establishes RAW/WAW dependency chain.
-  // Write outputs always overwrite read outputs in the mapping.
+  // Memory outputs (write): establishes RAW/WAW dependency chain and consumes
+  // pending reads for that memref.
   for (auto [memref, task_output] :
        llvm::zip(output_memrefs, task_op.getDependencyWriteOut())) {
-    value_mapping[memref] = task_output;
+    latest_write_out[memref] = task_output;
+    pending_read_outs[memref].clear();
   }
 
   return task_op;
@@ -366,6 +405,8 @@ static LogicalResult convertFuncToTaskflow(func::FuncOp func_op) {
       analyzeMemrefAccesses(func_op);
   OpBuilder builder(func_op.getContext());
   SmallVector<affine::AffineForOp> loops_to_erase;
+  DenseMap<Value, Value> latest_write_out;
+  DenseMap<Value, SmallVector<Value>> pending_read_outs;
   DenseMap<Value, Value> value_mapping;
   int task_id_counter = 0;
 
@@ -382,14 +423,46 @@ static LogicalResult convertFuncToTaskflow(func::FuncOp func_op) {
       llvm::errs() << *op << "\n";
     }
 
+    // Computes sparse read-out liveness. A task only needs to yield a read
+    // state when a later task in the same block writes the same original
+    // memref. Pure read-read sharing must not create dependence edges.
+    DenseMap<Operation *, SetVector<Value>> loop_to_read_output_memrefs;
+    DenseSet<Value> future_write_memrefs;
+    for (Operation *op : llvm::reverse(ops_to_process)) {
+      auto for_op = dyn_cast<affine::AffineForOp>(op);
+      if (!for_op) {
+        continue;
+      }
+
+      auto info_it = loop_to_original_memref_info.find(for_op.getOperation());
+      assert(info_it != loop_to_original_memref_info.end() &&
+             "Original memref access info not found for the loop");
+
+      const MemrefAccessInfo &access_info = info_it->second;
+      SetVector<Value> read_outputs;
+      for (Value memref : access_info.read_memrefs) {
+        if (future_write_memrefs.contains(memref) &&
+            !access_info.write_memrefs.contains(memref)) {
+          read_outputs.insert(memref);
+        }
+      }
+      loop_to_read_output_memrefs[for_op.getOperation()] = read_outputs;
+
+      for (Value memref : access_info.write_memrefs) {
+        future_write_memrefs.insert(memref);
+      }
+    }
+
     // Processes each operation in order (top to bottom).
     for (Operation *op : ops_to_process) {
       if (auto for_op = dyn_cast<affine::AffineForOp>(op)) {
         // Converts affine.for to taskflow.task.
         OpBuilder builder(for_op);
-        TaskflowTaskOp task_op =
-            convertLoopToTask(builder, for_op, value_mapping,
-                              loop_to_original_memref_info, task_id_counter++);
+        TaskflowTaskOp task_op = convertLoopToTask(
+            builder, for_op, latest_write_out, pending_read_outs, value_mapping,
+            loop_to_original_memref_info,
+            loop_to_read_output_memrefs[for_op.getOperation()],
+            task_id_counter++);
 
         // Replaces uses of loop results with task value outputs.
         for (auto [loop_result, task_value_output] :
@@ -398,8 +471,9 @@ static LogicalResult convertFuncToTaskflow(func::FuncOp func_op) {
         }
         loops_to_erase.push_back(for_op);
       } else {
-        // Updates operands of non-loop operations based on value_mapping.
-        updateOperationOperands(op, value_mapping);
+        // Updates operands of non-loop operations based on the taskflow values
+        // produced by earlier converted loops.
+        updateOperationOperands(op, latest_write_out, value_mapping);
       }
     }
   }

--- a/lib/TaskflowDialect/TaskflowOps.cpp
+++ b/lib/TaskflowDialect/TaskflowOps.cpp
@@ -132,12 +132,19 @@ ParseResult TaskflowTaskOp::parse(OpAsmParser &parser, OperationState &result) {
            static_cast<int32_t>(original_read_operands.size()),
            static_cast<int32_t>(original_write_operands.size())}));
 
-  // Adds result segment sizes.
-  // dependency_write_out count always equals dependency_write_in count.
-  // dependency_read_out count is the remaining MemRef results after
-  // subtracting write_out. It may be less than dependency_read_in count
-  // when not all read memrefs have a WAR dependency.
-  size_t num_write_outputs = write_operands.size();
+  // Adds result segment sizes. Read/write outputs are inferred from the
+  // terminator, because multiple dependency_write_in states may map to a
+  // single dependency_write_out state.
+  size_t num_read_outputs = 0;
+  size_t num_write_outputs = 0;
+  if (!body->empty()) {
+    if (auto yield_op =
+            dyn_cast<TaskflowYieldOp>(body->front().getTerminator())) {
+      num_read_outputs = yield_op.getReadResults().size();
+      num_write_outputs = yield_op.getMemoryResults().size();
+    }
+  }
+
   size_t num_value_outputs = 0;
   size_t total_memref_results = 0;
   for (Type t : func_type.getResults()) {
@@ -147,7 +154,11 @@ ParseResult TaskflowTaskOp::parse(OpAsmParser &parser, OperationState &result) {
       num_value_outputs++;
     }
   }
-  size_t num_read_outputs = total_memref_results - num_write_outputs;
+  if (total_memref_results != num_read_outputs + num_write_outputs) {
+    return parser.emitError(parser.getCurrentLocation(),
+                            "taskflow.yield memref result count does not "
+                            "match task function result type");
+  }
   result.addAttribute("resultSegmentSizes",
                       parser.getBuilder().getDenseI32ArrayAttr(
                           {static_cast<int32_t>(num_read_outputs),

--- a/lib/TaskflowDialect/TaskflowOps.cpp
+++ b/lib/TaskflowDialect/TaskflowOps.cpp
@@ -118,8 +118,9 @@ ParseResult TaskflowTaskOp::parse(OpAsmParser &parser, OperationState &result) {
 
   // Parses region.
   Region *body = result.addRegion();
-  if (parser.parseRegion(*body, /*args=*/{}, /*argTypes=*/{}))
+  if (parser.parseRegion(*body, /*args=*/{}, /*argTypes=*/{})) {
     return failure();
+  }
 
   // Adds operand segment sizes.
   result.addAttribute(
@@ -132,20 +133,21 @@ ParseResult TaskflowTaskOp::parse(OpAsmParser &parser, OperationState &result) {
            static_cast<int32_t>(original_write_operands.size())}));
 
   // Adds result segment sizes.
-  // dependency_read_out count matches dependency_read_in count (WAR dependency
-  // tracking).
-  size_t num_read_outputs = read_operands.size();
-  size_t num_write_outputs = 0;
+  // dependency_write_out count always equals dependency_write_in count.
+  // dependency_read_out count is the remaining MemRef results after
+  // subtracting write_out. It may be less than dependency_read_in count
+  // when not all read memrefs have a WAR dependency.
+  size_t num_write_outputs = write_operands.size();
   size_t num_value_outputs = 0;
+  size_t total_memref_results = 0;
   for (Type t : func_type.getResults()) {
-    if (isa<MemRefType>(t))
-      num_write_outputs++;
-    else
+    if (isa<MemRefType>(t)) {
+      total_memref_results++;
+    } else {
       num_value_outputs++;
+    }
   }
-  // Total memref results include both dependency_read_out and
-  // dependency_write_out.
-  num_write_outputs = num_write_outputs - num_read_outputs;
+  size_t num_read_outputs = total_memref_results - num_write_outputs;
   result.addAttribute("resultSegmentSizes",
                       parser.getBuilder().getDenseI32ArrayAttr(
                           {static_cast<int32_t>(num_read_outputs),

--- a/lib/TaskflowDialect/Transforms/Optimizations/ResourceAwareTaskOptimizationPass.cpp
+++ b/lib/TaskflowDialect/Transforms/Optimizations/ResourceAwareTaskOptimizationPass.cpp
@@ -867,9 +867,9 @@ public:
       // Check if incrementing cgra_count is feasible on the 4×4 grid.
       // TODO: This currently only checks the capacity (total CGRA count).
       // Ideally, we should invoke a global placement pass (aka
-      // OrchestrateTaskOnCgraPass) here to verify if the speculatively increased CGRA
-      // count and its proposed shape actually fit on the 4x4 grid alongside
-      // other previously allocated tasks.
+      // OrchestrateTaskOnCgraPass) here to verify if the speculatively
+      // increased CGRA count and its proposed shape actually fit on the 4x4
+      // grid alongside other previously allocated tasks.
       //
       // Currently, OrchestrateTaskOnCgraPass does not support multi-CGRA task
       // placement. Once it does, we should call it here; if global placement
@@ -1554,13 +1554,12 @@ private:
         OpBuilder b(fused_task);
         MLIRContext *ctx = fused_task->getContext();
         SmallVector<NamedAttribute, 1> profile_attrs;
-        profile_attrs.push_back(NamedAttribute(
-            StringAttr::get(ctx, "duration"),
-            b.getI32IntegerAttr(fused_node.steps)));
+        profile_attrs.push_back(
+            NamedAttribute(StringAttr::get(ctx, "duration"),
+                           b.getI32IntegerAttr(fused_node.steps)));
         fused_task->setAttr("profile_info",
                             DictionaryAttr::get(ctx, profile_attrs));
-        fused_task->setAttr("compiled_ii",
-                            b.getI64IntegerAttr(fused_node.ii));
+        fused_task->setAttr("compiled_ii", b.getI64IntegerAttr(fused_node.ii));
       }
     }
 
@@ -1780,9 +1779,9 @@ struct ResourceAwareTaskOptimizationPass
           }
           if (node->steps != kUnprofiled) {
             SmallVector<NamedAttribute, 1> profile_attrs;
-            profile_attrs.push_back(NamedAttribute(
-                StringAttr::get(b.getContext(), "duration"),
-                b.getI32IntegerAttr(node->steps)));
+            profile_attrs.push_back(
+                NamedAttribute(StringAttr::get(b.getContext(), "duration"),
+                               b.getI32IntegerAttr(node->steps)));
             node->op->setAttr(
                 "profile_info",
                 DictionaryAttr::get(b.getContext(), profile_attrs));
@@ -1829,9 +1828,9 @@ struct ResourceAwareTaskOptimizationPass
           node->op->setAttr("compiled_ii", b.getI32IntegerAttr(node->ii));
           {
             SmallVector<NamedAttribute, 1> profile_attrs;
-            profile_attrs.push_back(NamedAttribute(
-                StringAttr::get(b.getContext(), "duration"),
-                b.getI32IntegerAttr(node->steps)));
+            profile_attrs.push_back(
+                NamedAttribute(StringAttr::get(b.getContext(), "duration"),
+                               b.getI32IntegerAttr(node->steps)));
             node->op->setAttr(
                 "profile_info",
                 DictionaryAttr::get(b.getContext(), profile_attrs));

--- a/test/Conversion/tosa2taskflow/affine-to-taskflow.mlir
+++ b/test/Conversion/tosa2taskflow/affine-to-taskflow.mlir
@@ -16,7 +16,7 @@ module {
 }
 
 // CHECK:        func.func @simple_add(%arg0: memref<16xf32>, %arg1: memref<16xf32>, %arg2: memref<16xf32>) {
-// CHECK-NEXT:     %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) dependency_write_in(%arg2 : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%arg2 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>, memref<16xf32>, memref<16xf32>) {
+// CHECK-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) dependency_write_in(%arg2 : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%arg2 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
 // CHECK-NEXT:     ^bb0(%arg3: memref<16xf32>, %arg4: memref<16xf32>, %arg5: memref<16xf32>):
 // CHECK-NEXT:       affine.for %arg6 = 0 to 16 {
 // CHECK-NEXT:         %0 = affine.load %arg3[%arg6] : memref<16xf32>
@@ -24,7 +24,7 @@ module {
 // CHECK-NEXT:         %2 = arith.addf %0, %1 : f32
 // CHECK-NEXT:         affine.store %2, %arg5[%arg6] : memref<16xf32>
 // CHECK-NEXT:       }
-// CHECK-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<16xf32>, memref<16xf32>) writes(%arg5 : memref<16xf32>)
+// CHECK-NEXT:       taskflow.yield writes(%arg5 : memref<16xf32>)
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/test/Conversion/tosa2taskflow/tosa-to-taskflow.mlir
+++ b/test/Conversion/tosa2taskflow/tosa-to-taskflow.mlir
@@ -11,7 +11,7 @@ func.func @simple_add(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16
 
 // CHECK:      func.func @simple_add(%arg0: memref<16xf32>, %arg1: memref<16xf32>) -> memref<16xf32> {
 // CHECK-NEXT:   %alloc = memref.alloc() {alignment = 64 : i64} : memref<16xf32>
-// CHECK-NEXT:   %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) dependency_write_in(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>, memref<16xf32>, memref<16xf32>) {
+// CHECK-NEXT:   %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) dependency_write_in(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
 // CHECK-NEXT:   ^bb0(%arg2: memref<16xf32>, %arg3: memref<16xf32>, %arg4: memref<16xf32>):
 // CHECK-NEXT:     affine.for %arg5 = 0 to 16 {
 // CHECK-NEXT:       %0 = affine.load %arg2[%arg5] : memref<16xf32>
@@ -19,7 +19,7 @@ func.func @simple_add(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16
 // CHECK-NEXT:       %2 = arith.addf %0, %1 : f32
 // CHECK-NEXT:       affine.store %2, %arg4[%arg5] : memref<16xf32>
 // CHECK-NEXT:     }
-// CHECK-NEXT:     taskflow.yield reads(%arg2, %arg3 : memref<16xf32>, memref<16xf32>) writes(%arg4 : memref<16xf32>)
+// CHECK-NEXT:     taskflow.yield writes(%arg4 : memref<16xf32>)
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return %dependency_write_out : memref<16xf32>
 // CHECK-NEXT: }

--- a/test/e2e/tosa_e2e.mlir
+++ b/test/e2e/tosa_e2e.mlir
@@ -11,7 +11,7 @@ func.func @test_e2e(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf
 
 // CHECK:      func.func @test_e2e(%arg0: memref<16xf32>, %arg1: memref<16xf32>) -> memref<16xf32> {
 // CHECK-NEXT:   %alloc = memref.alloc() {alignment = 64 : i64} : memref<16xf32>
-// CHECK-NEXT:   %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) dependency_write_in(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>, memref<16xf32>, memref<16xf32>) {
+// CHECK-NEXT:   %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) dependency_write_in(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
 // CHECK-NEXT:   ^bb0(%arg2: memref<16xf32>, %arg3: memref<16xf32>, %arg4: memref<16xf32>):
 // CHECK-NEXT:     affine.for %arg5 = 0 to 16 {
 // CHECK-NEXT:       %0 = affine.load %arg2[%arg5] : memref<16xf32>
@@ -20,7 +20,7 @@ func.func @test_e2e(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf
 // CHECK-NEXT:       %3 = arith.mulf %2, %2 : f32
 // CHECK-NEXT:       affine.store %3, %arg4[%arg5] : memref<16xf32>
 // CHECK-NEXT:     }
-// CHECK-NEXT:     taskflow.yield reads(%arg2, %arg3 : memref<16xf32>, memref<16xf32>) writes(%arg4 : memref<16xf32>)
+// CHECK-NEXT:     taskflow.yield writes(%arg4 : memref<16xf32>)
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return %dependency_write_out : memref<16xf32>
 // CHECK-NEXT: }

--- a/test/multi-cgra/kernel_mapping/fir/fir.mlir
+++ b/test/multi-cgra/kernel_mapping/fir/fir.mlir
@@ -92,7 +92,7 @@ module attributes {} {
 // TASKFLOW: module {
 // TASKFLOW-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // TASKFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// TASKFLOW-NEXT:     %dependency_read_out:2, %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// TASKFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // TASKFLOW-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // TASKFLOW-NEXT:       %0 = affine.for %arg6 = 0 to 32 iter_args(%arg7 = %arg5) -> (i32) {
 // TASKFLOW-NEXT:         %1 = affine.load %arg3[%arg6] : memref<?xi32>
@@ -101,7 +101,7 @@ module attributes {} {
 // TASKFLOW-NEXT:         %4 = arith.addi %arg7, %3 : i32
 // TASKFLOW-NEXT:         affine.yield %4 : i32
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
+// TASKFLOW-NEXT:       taskflow.yield values(%0 : i32)
 // TASKFLOW-NEXT:     }
 // TASKFLOW-NEXT:     return %value_outputs : i32
 // TASKFLOW-NEXT:   }
@@ -110,7 +110,7 @@ module attributes {} {
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // HYPERBLOCK-NEXT:     %c0_i32 = arith.constant 0 : i32
-// HYPERBLOCK-NEXT:     %dependency_read_out:2, %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// HYPERBLOCK-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c32 = arith.constant 32 : index
@@ -124,7 +124,7 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         %5 = arith.addi %arg7, %4 : i32
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield iter_args_next(%5 : i32) results(%5 : i32)
 // HYPERBLOCK-NEXT:       }) : (index, i32) -> i32
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%1 : i32)
+// HYPERBLOCK-NEXT:       taskflow.yield values(%1 : i32)
 // HYPERBLOCK-NEXT:     }
 // HYPERBLOCK-NEXT:     return %value_outputs : i32
 // HYPERBLOCK-NEXT:   }
@@ -133,7 +133,7 @@ module attributes {} {
 // KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // KERNEL-NEXT:     %c0_i32 = arith.constant 0 : i32
-// KERNEL-NEXT:     %dependency_read_out:2, %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// KERNEL-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // KERNEL-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // KERNEL-NEXT:       %c0 = arith.constant 0 : index
 // KERNEL-NEXT:       %c32 = arith.constant 32 : index
@@ -151,7 +151,7 @@ module attributes {} {
 // KERNEL-NEXT:         %6 = arith.addi %arg8, %5 : i32
 // KERNEL-NEXT:         neura.yield iter_args_next(%6 : i32) results(%6 : i32)
 // KERNEL-NEXT:       } : i32
-// KERNEL-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%1 : i32)
+// KERNEL-NEXT:       taskflow.yield values(%1 : i32)
 // KERNEL-NEXT:     }
 // KERNEL-NEXT:     return %value_outputs : i32
 // KERNEL-NEXT:   }
@@ -160,7 +160,7 @@ module attributes {} {
 // NEURA:      module {
 // NEURA-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // NEURA-NEXT:     %c0_i32 = arith.constant 0 : i32
-// NEURA-NEXT:     %dependency_read_out:2, %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// NEURA-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // NEURA-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // NEURA-NEXT:       %c0 = arith.constant 0 : index
 // NEURA-NEXT:       %c32 = arith.constant 32 : index
@@ -178,7 +178,7 @@ module attributes {} {
 // NEURA-NEXT:         %9 = "neura.add"(%arg8, %8) : (i32, i32) -> i32
 // NEURA-NEXT:         neura.yield iter_args_next(%9 : i32) results(%9 : i32)
 // NEURA-NEXT:       } : i32
-// NEURA-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%1 : i32)
+// NEURA-NEXT:       taskflow.yield values(%1 : i32)
 // NEURA-NEXT:     }
 // NEURA-NEXT:     return %value_outputs : i32
 // NEURA-NEXT:   }
@@ -187,7 +187,7 @@ module attributes {} {
 // DATAFLOW:      module {
 // DATAFLOW-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // DATAFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// DATAFLOW-NEXT:     %dependency_read_out:2, %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// DATAFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // DATAFLOW-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // DATAFLOW-NEXT:       %c0 = arith.constant 0 : index
 // DATAFLOW-NEXT:       %c32 = arith.constant 32 : index
@@ -210,7 +210,7 @@ module attributes {} {
 // DATAFLOW-NEXT:         neura.return_value %12 : !neura.data<i32, i1>
 // DATAFLOW-NEXT:         neura.yield
 // DATAFLOW-NEXT:       } : i32
-// DATAFLOW-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%1 : i32)
+// DATAFLOW-NEXT:       taskflow.yield values(%1 : i32)
 // DATAFLOW-NEXT:     }
 // DATAFLOW-NEXT:     return %value_outputs : i32
 // DATAFLOW-NEXT:   }
@@ -219,7 +219,7 @@ module attributes {} {
 // MAPPED:      module {
 // MAPPED-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // MAPPED-NEXT:     %c0_i32 = arith.constant 0 : i32
-// MAPPED-NEXT:     %dependency_read_out:2, %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// MAPPED-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // MAPPED-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // MAPPED-NEXT:       %c0 = arith.constant 0 : index
 // MAPPED-NEXT:       %c32 = arith.constant 32 : index
@@ -254,7 +254,7 @@ module attributes {} {
 // MAPPED-NEXT:         neura.return_value %24 : !neura.data<i32, i1> {dfg_id = 25 : i32, mapping_locs = [{id = 8 : i32, index_per_ii = 0 : i32, invalid_iterations = 1 : i32, resource = "tile", time_step = 4 : i32, x = 0 : i32, y = 2 : i32}]}
 // MAPPED-NEXT:         neura.yield {dfg_id = 3 : i32}
 // MAPPED-NEXT:       } : i32
-// MAPPED-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%1 : i32)
+// MAPPED-NEXT:       taskflow.yield values(%1 : i32)
 // MAPPED-NEXT:     }
 // MAPPED-NEXT:     return %value_outputs : i32
 // MAPPED-NEXT:   }

--- a/test/multi-cgra/kernel_mapping/relu/relu.mlir
+++ b/test/multi-cgra/kernel_mapping/relu/relu.mlir
@@ -96,7 +96,7 @@ module attributes {} {
 // TASKFLOW: module {
 // TASKFLOW-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // TASKFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// TASKFLOW-NEXT:     %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// TASKFLOW-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // TASKFLOW-NEXT:       affine.for %arg6 = 0 to 32 {
 // TASKFLOW-NEXT:         %0 = affine.load %arg2[%arg6] : memref<?xi32>
@@ -111,7 +111,7 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %2, %arg4[%arg6] : memref<?xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg2, %arg4 : memref<?xi32>, memref<?xi32>) writes(%arg4 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
 // TASKFLOW-NEXT:     return
 // TASKFLOW-NEXT:   }
@@ -120,7 +120,7 @@ module attributes {} {
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // HYPERBLOCK-NEXT:     %c0_i32 = arith.constant 0 : i32
-// HYPERBLOCK-NEXT:     %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c32 = arith.constant 32 : index
@@ -141,7 +141,7 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         }
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg2, %arg4 : memref<?xi32>, memref<?xi32>) writes(%arg4 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
 // HYPERBLOCK-NEXT:     return
 // HYPERBLOCK-NEXT:   }
@@ -150,7 +150,7 @@ module attributes {} {
 // KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // KERNEL-NEXT:     %c0_i32 = arith.constant 0 : i32
-// KERNEL-NEXT:     %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// KERNEL-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // KERNEL-NEXT:       %c0 = arith.constant 0 : index
 // KERNEL-NEXT:       %c32 = arith.constant 32 : index
@@ -175,7 +175,7 @@ module attributes {} {
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:         neura.yield
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield reads(%arg2, %arg4 : memref<?xi32>, memref<?xi32>) writes(%arg4 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
 // KERNEL-NEXT:     }
 // KERNEL-NEXT:     return
 // KERNEL-NEXT:   }
@@ -184,7 +184,7 @@ module attributes {} {
 // NEURA:      module {
 // NEURA-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // NEURA-NEXT:     %c0_i32 = arith.constant 0 : i32
-// NEURA-NEXT:     %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// NEURA-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // NEURA-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // NEURA-NEXT:       %c0 = arith.constant 0 : index
 // NEURA-NEXT:       %c32 = arith.constant 32 : index
@@ -212,7 +212,7 @@ module attributes {} {
 // NEURA-NEXT:       ^bb3:  // 2 preds: ^bb1, ^bb2
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield reads(%arg2, %arg4 : memref<?xi32>, memref<?xi32>) writes(%arg4 : memref<?xi32>)
+// NEURA-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
 // NEURA-NEXT:     }
 // NEURA-NEXT:     return
 // NEURA-NEXT:   }
@@ -221,7 +221,7 @@ module attributes {} {
 // DATAFLOW:      module {
 // DATAFLOW-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // DATAFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// DATAFLOW-NEXT:     %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// DATAFLOW-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // DATAFLOW-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // DATAFLOW-NEXT:       %c0 = arith.constant 0 : index
 // DATAFLOW-NEXT:       %c32 = arith.constant 32 : index
@@ -243,7 +243,7 @@ module attributes {} {
 // DATAFLOW-NEXT:         neura.store_indexed %10 to [%4 : !neura.data<index, i1>]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // DATAFLOW-NEXT:         neura.yield {yield_type = "void"}
 // DATAFLOW-NEXT:       }
-// DATAFLOW-NEXT:       taskflow.yield reads(%arg2, %arg4 : memref<?xi32>, memref<?xi32>) writes(%arg4 : memref<?xi32>)
+// DATAFLOW-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
 // DATAFLOW-NEXT:     }
 // DATAFLOW-NEXT:     return
 // DATAFLOW-NEXT:   }
@@ -252,7 +252,7 @@ module attributes {} {
 // MAPPED:      module {
 // MAPPED-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // MAPPED-NEXT:     %c0_i32 = arith.constant 0 : i32
-// MAPPED-NEXT:     %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// MAPPED-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // MAPPED-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // MAPPED-NEXT:       %c0 = arith.constant 0 : index
 // MAPPED-NEXT:       %c32 = arith.constant 32 : index
@@ -290,7 +290,7 @@ module attributes {} {
 // MAPPED-NEXT:         neura.store_indexed %25 to [%26 : !neura.data<index, i1>]  {dfg_id = 28 : i32, mapping_locs = [{id = 7 : i32, index_per_ii = 1 : i32, invalid_iterations = 3 : i32, resource = "tile", time_step = 7 : i32, x = 3 : i32, y = 1 : i32}], rhs_value = "%input2"} : !neura.data<i32, i1>
 // MAPPED-NEXT:         neura.yield {dfg_id = 1 : i32, yield_type = "void"}
 // MAPPED-NEXT:       }
-// MAPPED-NEXT:       taskflow.yield reads(%arg2, %arg4 : memref<?xi32>, memref<?xi32>) writes(%arg4 : memref<?xi32>)
+// MAPPED-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
 // MAPPED-NEXT:     }
 // MAPPED-NEXT:     return
 // MAPPED-NEXT:   }

--- a/test/multi-cgra/taskflow/irregular-loop/irregular-loop.mlir
+++ b/test/multi-cgra/taskflow/irregular-loop/irregular-loop.mlir
@@ -204,8 +204,7 @@ module attributes {} {
 // PERFECT-NEXT:   }
 // PERFECT-NEXT: }
 
-// TASKFLOW: #set = affine_set<(d0, d1) : (d0 - 3 == 0, d1 - 7 == 0)>
-// TASKFLOW-NEXT: module {
+// TASKFLOW:      module {
 // TASKFLOW-NEXT:   func.func @_Z21irregularLoopExample1v() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // TASKFLOW-NEXT:     %c2_i32 = arith.constant 2 : i32
 // TASKFLOW-NEXT:     %c8_i32 = arith.constant 8 : i32
@@ -234,7 +233,7 @@ module attributes {} {
 // TASKFLOW-NEXT:       }
 // TASKFLOW-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_read_out, %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<4x8xi32>, memref<i32>) {
+// TASKFLOW-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // TASKFLOW-NEXT:       affine.for %arg5 = 0 to 4 {
 // TASKFLOW-NEXT:         %1 = arith.index_cast %arg5 : index to i32
@@ -249,14 +248,14 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg0 : memref<4x8xi32>) writes(%arg1 : memref<i32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
 // TASKFLOW-NEXT:     }
 // TASKFLOW-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
 // TASKFLOW-NEXT:     return %0 : i32
 // TASKFLOW-NEXT:   }
 // TASKFLOW-NEXT: }
 
-// KERNEL: module {
+// KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z21irregularLoopExample1v() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // KERNEL-NEXT:     %c2_i32 = arith.constant 2 : i32
 // KERNEL-NEXT:     %c8_i32 = arith.constant 8 : i32
@@ -299,7 +298,7 @@ module attributes {} {
 // KERNEL-NEXT:       }
 // KERNEL-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_read_out, %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<4x8xi32>, memref<i32>) {
+// KERNEL-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // KERNEL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // KERNEL-NEXT:       affine.for %arg5 = 0 to 4 {
 // KERNEL-NEXT:         neura.kernel inputs(%arg0, %arg5, %arg3, %arg1, %arg4 : memref<4x8xi32>, index, i32, memref<i32>, i32) {
@@ -326,7 +325,7 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield reads(%arg0 : memref<4x8xi32>) writes(%arg1 : memref<i32>)
+// KERNEL-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
 // KERNEL-NEXT:     }
 // KERNEL-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
 // KERNEL-NEXT:     return %0 : i32
@@ -376,7 +375,7 @@ module attributes {} {
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
 // HYPERBLOCK-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_read_out, %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<4x8xi32>, memref<i32>) {
+// HYPERBLOCK-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -408,7 +407,7 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         }
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg0 : memref<4x8xi32>) writes(%arg1 : memref<i32>)
+// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
 // HYPERBLOCK-NEXT:     }
 // HYPERBLOCK-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
 // HYPERBLOCK-NEXT:     return %0 : i32
@@ -416,7 +415,7 @@ module attributes {} {
 // HYPERBLOCK-NEXT: }
 
 
-// MAP-SPATIAL-TEMPORAL-4x4: module {
+// MAP-SPATIAL-TEMPORAL-4x4:      module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:   func.func @_Z21irregularLoopExample1v() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %c2_i32 = arith.constant 2 : i32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %c8_i32 = arith.constant 8 : i32
@@ -459,7 +458,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       }) : (index) -> ()
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %dependency_read_out, %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<4x8xi32>, memref<i32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c4 = arith.constant 4 : index
@@ -491,7 +490,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield reads(%arg0 : memref<4x8xi32>) writes(%arg1 : memref<i32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     return %0 : i32
@@ -541,7 +540,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       }) : (index) -> ()
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %dependency_read_out, %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<4x8xi32>, memref<i32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c4 = arith.constant 4 : index
@@ -573,7 +572,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield reads(%arg0 : memref<4x8xi32>) writes(%arg1 : memref<i32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     return %0 : i32
@@ -623,7 +622,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       }) : (index) -> ()
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %dependency_read_out, %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<4x8xi32>, memref<i32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c4 = arith.constant 4 : index
@@ -655,7 +654,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield reads(%arg0 : memref<4x8xi32>) writes(%arg1 : memref<i32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     return %0 : i32
@@ -705,7 +704,7 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:       }) : (index) -> ()
 // MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_read_out, %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<4x8xi32>, memref<i32>) {
+// MAP-SPATIAL-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -737,7 +736,7 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         }
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield reads(%arg0 : memref<4x8xi32>) writes(%arg1 : memref<i32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
 // MAP-SPATIAL-NEXT:     }
 // MAP-SPATIAL-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
 // MAP-SPATIAL-NEXT:     return %0 : i32
@@ -788,7 +787,7 @@ module attributes {} {
 // RESOPT-NEXT:       %4 = taskflow.counter parent(%3 : index) from %c0_2 to %c8 step %c1_3 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
 // RESOPT-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>) values(%2 : i32)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %dependency_read_out, %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 7 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<4x8xi32>, memref<i32>) {
+// RESOPT-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 7 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // RESOPT-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
 // RESOPT-NEXT:       %c0 = arith.constant 0 : index
@@ -813,7 +812,7 @@ module attributes {} {
 // RESOPT-NEXT:         neura.store_indexed %13 to [ : ]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       taskflow.yield reads(%arg0 : memref<4x8xi32>) writes(%arg1 : memref<i32>)
+// RESOPT-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
 // RESOPT-NEXT:     }
 // RESOPT-NEXT:     %0 = memref.load %dependency_write_out_1[] : memref<i32>
 // RESOPT-NEXT:     return %0 : i32

--- a/test/multi-cgra/taskflow/multi-nested/multi-nested.mlir
+++ b/test/multi-cgra/taskflow/multi-nested/multi-nested.mlir
@@ -236,9 +236,9 @@ module attributes {} {
 // PERFECT-NEXT:   }
 // PERFECT-NEXT: }
 
-// TASKFLOW: module {
+// TASKFLOW:      module {
 // TASKFLOW-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// TASKFLOW-NEXT:     %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>) {
+// TASKFLOW-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg12 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg13 = 0 to 8 {
@@ -248,9 +248,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg10 : memref<?x8x6xi32>) writes(%arg11 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) {
+// TASKFLOW-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg13 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg14 = 0 to 8 {
@@ -262,9 +262,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x8x5xi32>, memref<?x8x5xi32>) writes(%arg12 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_read_out_2:3, %dependency_write_out_3 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_1, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// TASKFLOW-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg14 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg15 = 0 to 8 {
@@ -278,9 +278,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg10, %arg11, %arg13 : memref<?xi32>, memref<?xi32>, memref<?xi32>) writes(%arg13 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg13 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_read_out_4, %dependency_write_out_5 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?x7xi32>, memref<?xi32>) {
+// TASKFLOW-NEXT:     %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg12 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg13 = 0 to 7 {
@@ -288,9 +288,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %1, %arg11[%arg13] : memref<?xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg10 : memref<?x7xi32>) writes(%arg11 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_read_out_6:2, %dependency_write_out_7 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_5 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) {
+// TASKFLOW-NEXT:     %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg13 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg14 = 0 to 9 {
@@ -300,16 +300,16 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %3, %arg12[%arg14] : memref<?xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x9xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %0 = affine.load %dependency_write_out_3[0] : memref<?xi32>
+// TASKFLOW-NEXT:     %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
 // TASKFLOW-NEXT:     return %0 : i32
 // TASKFLOW-NEXT:   }
 // TASKFLOW-NEXT: }
 
-// STREAM: module {
+// STREAM:      module {
 // STREAM-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// STREAM-NEXT:     %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) {
+// STREAM-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg13 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg14 = 0 to 8 {
@@ -321,9 +321,9 @@ module attributes {} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x8x5xi32>, memref<?x8x5xi32>) writes(%arg12 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_read_out_0:3, %dependency_write_out_1 = taskflow.task @Task_0_Task_2_fused dependency_read_in(%arg0, %dependency_write_out, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// STREAM-NEXT:     %dependency_read_out:3, %dependency_write_out_0 = taskflow.task @Task_0_Task_2_fused dependency_read_in(%arg0, %dependency_write_out, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg14 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg15 = 0 to 8 {
@@ -339,7 +339,7 @@ module attributes {} {
 // STREAM-NEXT:       }
 // STREAM-NEXT:       taskflow.yield reads(%arg10, %arg11, %arg12 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_read_out_2, %dependency_write_out_3 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?x7xi32>, memref<?xi32>) {
+// STREAM-NEXT:     %dependency_write_out_1 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg12 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg13 = 0 to 7 {
@@ -347,9 +347,9 @@ module attributes {} {
 // STREAM-NEXT:           affine.store %1, %arg11[%arg13] : memref<?xi32>
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg10 : memref<?x7xi32>) writes(%arg11 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_read_out_4:2, %dependency_write_out_5 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_3 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) {
+// STREAM-NEXT:     %dependency_write_out_2 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_1 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg13 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg14 = 0 to 9 {
@@ -359,16 +359,16 @@ module attributes {} {
 // STREAM-NEXT:           affine.store %3, %arg12[%arg14] : memref<?xi32>
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x9xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
+// STREAM-NEXT:     %0 = affine.load %dependency_write_out_0[0] : memref<?xi32>
 // STREAM-NEXT:     return %0 : i32
 // STREAM-NEXT:   }
 // STREAM-NEXT: }
 
-// KERNEL: module {
+// KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// KERNEL-NEXT:     %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>) {
+// KERNEL-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg12 = 0 to 4 {
 // KERNEL-NEXT:         affine.for %arg13 = 0 to 8 {
@@ -385,9 +385,9 @@ module attributes {} {
 // KERNEL-NEXT:           }
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield reads(%arg10 : memref<?x8x6xi32>) writes(%arg11 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) {
+// KERNEL-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg13 = 0 to 4 {
 // KERNEL-NEXT:         affine.for %arg14 = 0 to 8 {
@@ -406,9 +406,9 @@ module attributes {} {
 // KERNEL-NEXT:           }
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x8x5xi32>, memref<?x8x5xi32>) writes(%arg12 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_read_out_2:3, %dependency_write_out_3 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_1, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// KERNEL-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg14 = 0 to 4 {
 // KERNEL-NEXT:         affine.for %arg15 = 0 to 8 {
@@ -429,9 +429,9 @@ module attributes {} {
 // KERNEL-NEXT:           }
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield reads(%arg10, %arg11, %arg13 : memref<?xi32>, memref<?xi32>, memref<?xi32>) writes(%arg13 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield writes(%arg13 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_read_out_4, %dependency_write_out_5 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?x7xi32>, memref<?xi32>) {
+// KERNEL-NEXT:     %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg12 = 0 to 4 {
 // KERNEL-NEXT:         neura.kernel inputs(%arg10, %arg12, %arg11 : memref<?x7xi32>, index, memref<?xi32>) {
@@ -446,9 +446,9 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield reads(%arg10 : memref<?x7xi32>) writes(%arg11 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_read_out_6:2, %dependency_write_out_7 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_5 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) {
+// KERNEL-NEXT:     %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg13 = 0 to 4 {
 // KERNEL-NEXT:         neura.kernel inputs(%arg10, %arg13, %arg11, %arg12 : memref<?x9xi32>, index, memref<?xi32>, memref<?xi32>) {
@@ -465,16 +465,16 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x9xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %0 = affine.load %dependency_write_out_3[0] : memref<?xi32>
+// KERNEL-NEXT:     %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
 // KERNEL-NEXT:     return %0 : i32
 // KERNEL-NEXT:   }
 // KERNEL-NEXT: }
 
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// HYPERBLOCK-NEXT:     %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -490,9 +490,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %4, %arg11[%arg14] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg10 : memref<?x8x6xi32>) writes(%arg11 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -510,9 +510,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %6, %arg12[%arg15] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x8x5xi32>, memref<?x8x5xi32>) writes(%arg12 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_read_out_2:3, %dependency_write_out_3 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_1, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -527,16 +527,16 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         %4 = memref.load %arg10[%arg14] : memref<?xi32>
 // HYPERBLOCK-NEXT:         %5 = memref.load %arg11[%arg14] : memref<?xi32>
 // HYPERBLOCK-NEXT:         %6 = arith.addi %4, %5 : i32
-// HYPERBLOCK-NEXT:         %c0_8 = arith.constant 0 : index
-// HYPERBLOCK-NEXT:         %7 = memref.load %arg13[%c0_8] : memref<?xi32>
+// HYPERBLOCK-NEXT:         %c0_4 = arith.constant 0 : index
+// HYPERBLOCK-NEXT:         %7 = memref.load %arg13[%c0_4] : memref<?xi32>
 // HYPERBLOCK-NEXT:         %8 = arith.addi %7, %6 : i32
-// HYPERBLOCK-NEXT:         %c0_9 = arith.constant 0 : index
-// HYPERBLOCK-NEXT:         memref.store %8, %arg13[%c0_9] : memref<?xi32>
+// HYPERBLOCK-NEXT:         %c0_5 = arith.constant 0 : index
+// HYPERBLOCK-NEXT:         memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg10, %arg11, %arg13 : memref<?xi32>, memref<?xi32>, memref<?xi32>) writes(%arg13 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg13 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_read_out_4, %dependency_write_out_5 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?x7xi32>, memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -550,9 +550,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %3, %arg11[%arg13] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg10 : memref<?x7xi32>) writes(%arg11 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_read_out_6:2, %dependency_write_out_7 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_5 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -568,17 +568,17 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %5, %arg12[%arg14] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x9xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %0 = affine.load %dependency_write_out_3[0] : memref<?xi32>
+// HYPERBLOCK-NEXT:     %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
 // HYPERBLOCK-NEXT:     return %0 : i32
 // HYPERBLOCK-NEXT:   }
 // HYPERBLOCK-NEXT: }
 
 
-// MAP-SPATIAL-TEMPORAL-4x4:      module {
+// MAP-SPATIAL-TEMPORAL-4x4:     module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -594,9 +594,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg10 : memref<?x8x6xi32>) writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -614,9 +614,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg10, %arg11 : memref<?x8x5xi32>, memref<?x8x5xi32>) writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_2:3, %dependency_write_out_3 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_1, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -631,16 +631,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %4 = memref.load %arg10[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %5 = memref.load %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %6 = arith.addi %4, %5 : i32
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %c0_8 = arith.constant 0 : index
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %7 = memref.load %arg13[%c0_8] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %c0_4 = arith.constant 0 : index
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %7 = memref.load %arg13[%c0_4] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %8 = arith.addi %7, %6 : i32
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %c0_9 = arith.constant 0 : index
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %8, %arg13[%c0_9] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:        %c0_5 = arith.constant 0 : index
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg10, %arg11, %arg13 : memref<?xi32>, memref<?xi32>, memref<?xi32>) writes(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_4, %dependency_write_out_5 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?x7xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -654,9 +654,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg10 : memref<?x7xi32>) writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_6:2, %dependency_write_out_7 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_5 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -672,16 +672,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg10, %arg11 : memref<?x9xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %0 = affine.load %dependency_write_out_3[0] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return %0 : i32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:}
 
-// MAP-SPATIAL-TEMPORAL-1x1:      module {
+// MAP-SPATIAL-TEMPORAL-1x1:     module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -697,9 +697,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg10 : memref<?x8x6xi32>) writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -717,9 +717,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg10, %arg11 : memref<?x8x5xi32>, memref<?x8x5xi32>) writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_2:3, %dependency_write_out_3 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_1, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -734,16 +734,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %4 = memref.load %arg10[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %5 = memref.load %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %6 = arith.addi %4, %5 : i32
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %c0_8 = arith.constant 0 : index
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %7 = memref.load %arg13[%c0_8] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %c0_4 = arith.constant 0 : index
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %7 = memref.load %arg13[%c0_4] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %8 = arith.addi %7, %6 : i32
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %c0_9 = arith.constant 0 : index
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %8, %arg13[%c0_9] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:        %c0_5 = arith.constant 0 : index
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg10, %arg11, %arg13 : memref<?xi32>, memref<?xi32>, memref<?xi32>) writes(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_4, %dependency_write_out_5 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?x7xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -757,9 +757,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg10 : memref<?x7xi32>) writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_6:2, %dependency_write_out_7 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_5 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -775,16 +775,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg10, %arg11 : memref<?x9xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %0 = affine.load %dependency_write_out_3[0] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:}
 
-// MAP-SPATIAL-TEMPORAL-1x2:      module {
+// MAP-SPATIAL-TEMPORAL-1x2:     module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -800,9 +800,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg10 : memref<?x8x6xi32>) writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -820,9 +820,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg10, %arg11 : memref<?x8x5xi32>, memref<?x8x5xi32>) writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_2:3, %dependency_write_out_3 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_1, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -837,16 +837,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %4 = memref.load %arg10[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %5 = memref.load %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %6 = arith.addi %4, %5 : i32
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %c0_8 = arith.constant 0 : index
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %7 = memref.load %arg13[%c0_8] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %c0_4 = arith.constant 0 : index
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %7 = memref.load %arg13[%c0_4] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %8 = arith.addi %7, %6 : i32
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %c0_9 = arith.constant 0 : index
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %8, %arg13[%c0_9] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:        %c0_5 = arith.constant 0 : index
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg10, %arg11, %arg13 : memref<?xi32>, memref<?xi32>, memref<?xi32>) writes(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_4, %dependency_write_out_5 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?x7xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -860,9 +860,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg10 : memref<?x7xi32>) writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_6:2, %dependency_write_out_7 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_5 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -878,16 +878,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg10, %arg11 : memref<?x9xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %0 = affine.load %dependency_write_out_3[0] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:}
 
 // MAP-SPATIAL:      module {
 // MAP-SPATIAL-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-NEXT:     %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -903,9 +903,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield reads(%arg10 : memref<?x8x6xi32>) writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -923,9 +923,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x8x5xi32>, memref<?x8x5xi32>) writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_read_out_2:3, %dependency_write_out_3 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_1, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -940,16 +940,16 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         %4 = memref.load %arg10[%arg14] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         %5 = memref.load %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         %6 = arith.addi %4, %5 : i32
-// MAP-SPATIAL-NEXT:         %c0_8 = arith.constant 0 : index
-// MAP-SPATIAL-NEXT:         %7 = memref.load %arg13[%c0_8] : memref<?xi32>
+// MAP-SPATIAL-NEXT:         %c0_4 = arith.constant 0 : index
+// MAP-SPATIAL-NEXT:         %7 = memref.load %arg13[%c0_4] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         %8 = arith.addi %7, %6 : i32
-// MAP-SPATIAL-NEXT:         %c0_9 = arith.constant 0 : index
-// MAP-SPATIAL-NEXT:         memref.store %8, %arg13[%c0_9] : memref<?xi32>
+// MAP-SPATIAL-NEXT:         %c0_5 = arith.constant 0 : index
+// MAP-SPATIAL-NEXT:         memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield reads(%arg10, %arg11, %arg13 : memref<?xi32>, memref<?xi32>, memref<?xi32>) writes(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_read_out_4, %dependency_write_out_5 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?x7xi32>, memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -963,9 +963,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield reads(%arg10 : memref<?x7xi32>) writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_read_out_6:2, %dependency_write_out_7 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_5 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -981,9 +981,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x9xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %0 = affine.load %dependency_write_out_3[0] : memref<?xi32>
+// MAP-SPATIAL-NEXT:     %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
 // MAP-SPATIAL-NEXT:     return %0 : i32
 // MAP-SPATIAL-NEXT:   }
 // MAP-SPATIAL-NEXT: }
@@ -992,16 +992,16 @@ module attributes {} {
 // RESOPT:      module {
 // RESOPT-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // RESOPT-NEXT:     %c0 = arith.constant 0 : index
-// RESOPT-NEXT:     %dependency_read_out:2, %dependency_write_out = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 160 : i32} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) {
+// RESOPT-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 160 : i32} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // RESOPT-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // RESOPT-NEXT:       %c5 = arith.constant 5 : index
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
-// RESOPT-NEXT:       %c0_4 = arith.constant 0 : index
+// RESOPT-NEXT:       %c0_2 = arith.constant 0 : index
 // RESOPT-NEXT:       %c4 = arith.constant 4 : index
 // RESOPT-NEXT:       %c1 = arith.constant 1 : index
-// RESOPT-NEXT:       %1 = taskflow.counter from %c0_4 to %c4 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
-// RESOPT-NEXT:       %2 = taskflow.counter parent(%1 : index) from %c0_4 to %c8 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       %3 = taskflow.counter parent(%2 : index) from %c0_4 to %c5 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} : index
+// RESOPT-NEXT:       %1 = taskflow.counter from %c0_2 to %c4 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
+// RESOPT-NEXT:       %2 = taskflow.counter parent(%1 : index) from %c0_2 to %c8 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
+// RESOPT-NEXT:       %3 = taskflow.counter parent(%2 : index) from %c0_2 to %c5 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} : index
 // RESOPT-NEXT:       neura.kernel inputs(%arg10, %arg11, %arg12 : memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) attributes {accelerator = "neura", dataflow_mode = "predicate"} {
 // RESOPT-NEXT:       ^bb0(%arg13: memref<?x8x5xi32>, %arg14: memref<?x8x5xi32>, %arg15: memref<?xi32>):
 // RESOPT-NEXT:         %4 = neura.counter attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32, lower_bound_value = 0 : index, step_value = 1 : index, upper_bound_value = 4 : index} -> !neura.data<index, i1>
@@ -1013,18 +1013,18 @@ module attributes {} {
 // RESOPT-NEXT:         neura.store_indexed %9 to [%6 : !neura.data<index, i1>]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x8x5xi32>, memref<?x8x5xi32>) writes(%arg12 : memref<?xi32>)
+// RESOPT-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %dependency_read_out_0:4, %dependency_write_out_1:2 = taskflow.task @Task_0_Task_2_fused_Task_3_utilfused dependency_read_in(%arg0, %dependency_write_out, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) dependency_write_in(%arg9, %arg7 : memref<?xi32>, memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>), original_write_memrefs(%arg9, %arg7 : memref<?xi32>, memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 5 : i32}, trip_count = 192 : i32} : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) {
+// RESOPT-NEXT:     %dependency_read_out:4, %dependency_write_out_0:2 = taskflow.task @Task_0_Task_2_fused_Task_3_utilfused dependency_read_in(%arg0, %dependency_write_out, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) dependency_write_in(%arg9, %arg7 : memref<?xi32>, memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>), original_write_memrefs(%arg9, %arg7 : memref<?xi32>, memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 5 : i32}, trip_count = 192 : i32} : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) {
 // RESOPT-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?x7xi32>, %arg14: memref<?xi32>, %arg15: memref<?xi32>):
 // RESOPT-NEXT:       %c6 = arith.constant 6 : index
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
-// RESOPT-NEXT:       %c0_4 = arith.constant 0 : index
+// RESOPT-NEXT:       %c0_2 = arith.constant 0 : index
 // RESOPT-NEXT:       %c4 = arith.constant 4 : index
 // RESOPT-NEXT:       %c1 = arith.constant 1 : index
-// RESOPT-NEXT:       %1 = taskflow.counter from %c0_4 to %c4 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
-// RESOPT-NEXT:       %2 = taskflow.counter parent(%1 : index) from %c0_4 to %c8 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       %3 = taskflow.counter parent(%2 : index) from %c0_4 to %c6 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} : index
+// RESOPT-NEXT:       %1 = taskflow.counter from %c0_2 to %c4 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
+// RESOPT-NEXT:       %2 = taskflow.counter parent(%1 : index) from %c0_2 to %c8 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
+// RESOPT-NEXT:       %3 = taskflow.counter parent(%2 : index) from %c0_2 to %c6 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} : index
 // RESOPT-NEXT:       neura.kernel inputs(%arg10, %arg11, %arg12, %arg13, %arg15 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>) attributes {accelerator = "neura", dataflow_mode = "predicate"} {
 // RESOPT-NEXT:       ^bb0(%arg16: memref<?x8x6xi32>, %arg17: memref<?xi32>, %arg18: memref<?xi32>, %arg19: memref<?x7xi32>, %arg20: memref<?xi32>):
 // RESOPT-NEXT:         %6 = "neura.constant"() <{value = 0 : index}> : () -> !neura.data<index, i1>
@@ -1044,21 +1044,21 @@ module attributes {} {
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
 // RESOPT-NEXT:       %c7 = arith.constant 7 : index
-// RESOPT-NEXT:       %c0_5 = arith.constant 0 : index
-// RESOPT-NEXT:       %c4_6 = arith.constant 4 : index
-// RESOPT-NEXT:       %c1_7 = arith.constant 1 : index
-// RESOPT-NEXT:       %4 = taskflow.counter from %c0_5 to %c4_6 step %c1_7 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
-// RESOPT-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_5 to %c7 step %c1_7 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
+// RESOPT-NEXT:       %c0_3 = arith.constant 0 : index
+// RESOPT-NEXT:       %c4_4 = arith.constant 4 : index
+// RESOPT-NEXT:       %c1_5 = arith.constant 1 : index
+// RESOPT-NEXT:       %4 = taskflow.counter from %c0_3 to %c4_4 step %c1_5 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
+// RESOPT-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_3 to %c7 step %c1_5 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
 // RESOPT-NEXT:       taskflow.yield reads(%arg10, %arg11, %arg12, %arg13 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) writes(%arg14, %arg15 : memref<?xi32>, memref<?xi32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %dependency_read_out_2:2, %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_1#1 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 36 : i32} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) {
+// RESOPT-NEXT:     %dependency_write_out_1 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_0#1 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 36 : i32} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // RESOPT-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // RESOPT-NEXT:       %c9 = arith.constant 9 : index
-// RESOPT-NEXT:       %c0_4 = arith.constant 0 : index
+// RESOPT-NEXT:       %c0_2 = arith.constant 0 : index
 // RESOPT-NEXT:       %c4 = arith.constant 4 : index
 // RESOPT-NEXT:       %c1 = arith.constant 1 : index
-// RESOPT-NEXT:       %1 = taskflow.counter from %c0_4 to %c4 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
-// RESOPT-NEXT:       %2 = taskflow.counter parent(%1 : index) from %c0_4 to %c9 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
+// RESOPT-NEXT:       %1 = taskflow.counter from %c0_2 to %c4 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
+// RESOPT-NEXT:       %2 = taskflow.counter parent(%1 : index) from %c0_2 to %c9 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
 // RESOPT-NEXT:       neura.kernel inputs(%arg10, %arg11, %arg12 : memref<?x9xi32>, memref<?xi32>, memref<?xi32>) attributes {accelerator = "neura", dataflow_mode = "predicate"} {
 // RESOPT-NEXT:       ^bb0(%arg13: memref<?x9xi32>, %arg14: memref<?xi32>, %arg15: memref<?xi32>):
 // RESOPT-NEXT:         %3 = neura.counter attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32, lower_bound_value = 0 : index, step_value = 1 : index, upper_bound_value = 4 : index} -> !neura.data<index, i1>
@@ -1069,9 +1069,9 @@ module attributes {} {
 // RESOPT-NEXT:         neura.store_indexed %7 to [%4 : !neura.data<index, i1>]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       taskflow.yield reads(%arg10, %arg11 : memref<?x9xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// RESOPT-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %0 = memref.load %dependency_write_out_1#0[%c0] : memref<?xi32>
+// RESOPT-NEXT:     %0 = memref.load %dependency_write_out_0#0[%c0] : memref<?xi32>
 // RESOPT-NEXT:     return %0 : i32
 // RESOPT-NEXT:   }
 // RESOPT-NEXT: }

--- a/test/multi-cgra/taskflow/parallel-nested/parallel-nested.mlir
+++ b/test/multi-cgra/taskflow/parallel-nested/parallel-nested.mlir
@@ -126,28 +126,28 @@ module {
 // SERIALIZED-NEXT:   }
 // SERIALIZED-NEXT: }
 
-// TASKFLOW: module {
+// TASKFLOW:      module {
 // TASKFLOW-NEXT:   func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// TASKFLOW-NEXT:     %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>, memref<16xf32>) {
+// TASKFLOW-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // TASKFLOW-NEXT:       affine.for %arg8 = 0 to 16 {
 // TASKFLOW-NEXT:         %0 = affine.load %arg6[%arg8] : memref<16xf32>
 // TASKFLOW-NEXT:         %1 = arith.mulf %0, %arg7 : f32
 // TASKFLOW-NEXT:         affine.store %1, %arg6[%arg8] : memref<16xf32>
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg6 : memref<16xf32>) writes(%arg6 : memref<16xf32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg6 : memref<16xf32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) {
+// TASKFLOW-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // TASKFLOW-NEXT:       affine.for %arg8 = 0 to 8 {
 // TASKFLOW-NEXT:         affine.for %arg9 = 0 to 8 {
 // TASKFLOW-NEXT:           %0 = affine.load %arg5[%arg8, %arg9] : memref<8x8xf32>
 // TASKFLOW-NEXT:           %1 = affine.load %arg6[%arg8, %arg9] : memref<8x8xf32>
-// TASKFLOW-NEXT:           %2 = arith.mulf %0, %1 : f32
+// TASKFLOW-NEXT:          %2 = arith.mulf %0, %1 : f32
 // TASKFLOW-NEXT:           affine.store %2, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg5, %arg6 : memref<8x8xf32>, memref<8x8xf32>) writes(%arg7 : memref<8x8xf32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg7 : memref<8x8xf32>)
 // TASKFLOW-NEXT:     }
 // TASKFLOW-NEXT:     return
 // TASKFLOW-NEXT:   }
@@ -155,7 +155,7 @@ module {
 
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// HYPERBLOCK-NEXT:     %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>, memref<16xf32>) {
+// HYPERBLOCK-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c16 = arith.constant 16 : index
@@ -163,19 +163,19 @@ module {
 // HYPERBLOCK-NEXT:       %0 = taskflow.counter from %c0 to %c16 step %c1 : index
 // HYPERBLOCK-NEXT:       "taskflow.hyperblock"(%0) <{operandSegmentSizes = array<i32: 1, 0>}> ({
 // HYPERBLOCK-NEXT:       ^bb0(%arg8: index):
-// HYPERBLOCK-NEXT:         %1 = memref.load %arg6[%arg8] : memref<16xf32>
+// HYPERBLOCK-NEXT:        %1 = memref.load %arg6[%arg8] : memref<16xf32>
 // HYPERBLOCK-NEXT:         %2 = arith.mulf %1, %arg7 : f32
 // HYPERBLOCK-NEXT:         memref.store %2, %arg6[%arg8] : memref<16xf32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg6 : memref<16xf32>) writes(%arg6 : memref<16xf32>)
+// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg6 : memref<16xf32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) {
+// HYPERBLOCK-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c8 = arith.constant 8 : index
 // HYPERBLOCK-NEXT:       %c1 = arith.constant 1 : index
-// HYPERBLOCK-NEXT:       %0 = taskflow.counter from %c0 to %c8 step %c1 : index
+// HYPERBLOCK-NEXT:      %0 = taskflow.counter from %c0 to %c8 step %c1 : index
 // HYPERBLOCK-NEXT:       %1 = taskflow.counter parent(%0 : index) from %c0 to %c8 step %c1 : index
 // HYPERBLOCK-NEXT:       "taskflow.hyperblock"(%0, %1) <{operandSegmentSizes = array<i32: 2, 0>}> ({
 // HYPERBLOCK-NEXT:       ^bb0(%arg8: index, %arg9: index):
@@ -185,16 +185,16 @@ module {
 // HYPERBLOCK-NEXT:         memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield reads(%arg5, %arg6 : memref<8x8xf32>, memref<8x8xf32>) writes(%arg7 : memref<8x8xf32>)
+// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg7 : memref<8x8xf32>)
 // HYPERBLOCK-NEXT:     }
 // HYPERBLOCK-NEXT:     return
 // HYPERBLOCK-NEXT:   }
 // HYPERBLOCK-NEXT: }
 
 
-// MAP-SPATIAL-TEMPORAL-4x4:      module {
+// MAP-SPATIAL-TEMPORAL-4x4:     module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>, memref<16xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c16 = arith.constant 16 : index
@@ -207,9 +207,9 @@ module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg6 : memref<16xf32>) writes(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c8 = arith.constant 8 : index
@@ -224,15 +224,15 @@ module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg5, %arg6 : memref<8x8xf32>, memref<8x8xf32>) writes(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:}
 
-// MAP-SPATIAL-TEMPORAL-1x1:      module {
+// MAP-SPATIAL-TEMPORAL-1x1:     module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>, memref<16xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c16 = arith.constant 16 : index
@@ -245,9 +245,9 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg6 : memref<16xf32>) writes(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c8 = arith.constant 8 : index
@@ -262,15 +262,15 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg5, %arg6 : memref<8x8xf32>, memref<8x8xf32>) writes(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:}
 
-// MAP-SPATIAL-TEMPORAL-1x2:      module {
+// MAP-SPATIAL-TEMPORAL-1x2:     module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>, memref<16xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c16 = arith.constant 16 : index
@@ -283,9 +283,9 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg6 : memref<16xf32>) writes(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c8 = arith.constant 8 : index
@@ -300,15 +300,15 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg5, %arg6 : memref<8x8xf32>, memref<8x8xf32>) writes(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:}
 
-// MAP-SPATIAL:      module {
+// MAP-SPATIAL:     module {
 // MAP-SPATIAL-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>, memref<16xf32>) {
+// MAP-SPATIAL-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:      %c16 = arith.constant 16 : index
@@ -321,9 +321,9 @@ module {
 // MAP-SPATIAL-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-NEXT:      taskflow.yield reads(%arg6 : memref<16xf32>) writes(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-NEXT:      taskflow.yield writes(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-NEXT:    }
-// MAP-SPATIAL-NEXT:    %dependency_read_out_0:2, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) {
+// MAP-SPATIAL-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:      %c8 = arith.constant 8 : index
@@ -338,7 +338,7 @@ module {
 // MAP-SPATIAL-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-NEXT:      taskflow.yield reads(%arg5, %arg6 : memref<8x8xf32>, memref<8x8xf32>) writes(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-NEXT:      taskflow.yield writes(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-NEXT:    }
 // MAP-SPATIAL-NEXT:    return
 // MAP-SPATIAL-NEXT:  }

--- a/test/multi-cgra/taskflow/resnet/simple_resnet_tosa.mlir
+++ b/test/multi-cgra/taskflow/resnet/simple_resnet_tosa.mlir
@@ -262,7 +262,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // AFFINE-NEXT:   }
 // AFFINE-NEXT: }
 
-// KERNEL:      %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {dlp_replicable = true} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
+// KERNEL:          %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {dlp_replicable = true} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // KERNEL-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // KERNEL-NEXT:       %c64 = arith.constant 64 : index
 // KERNEL-NEXT:       %c8 = arith.constant 8 : index
@@ -274,23 +274,23 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // KERNEL-NEXT:       %3 = taskflow.counter parent(%2 : index) from %c0 to %c64 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 3 : i32} : index
 // KERNEL-NEXT:       neura.kernel inputs(%arg1, %arg2 : memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
 // KERNEL-NEXT:       ^bb0(%arg3: memref<1x64x8x8xf32>, %arg4: memref<1x8x8x64xf32>):
-// KERNEL-NEXT:         %c64_33 = arith.constant 64 : index
-// KERNEL-NEXT:         %c8_34 = arith.constant 8 : index
-// KERNEL-NEXT:         %c0_35 = arith.constant 0 : index
-// KERNEL-NEXT:         %c1_36 = arith.constant 1 : index
-// KERNEL-NEXT:         %4 = neura.counter from %c0_35 : index to %c1_36 : index step %c1_36 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} -> index
-// KERNEL-NEXT:         %5 = neura.counter from %c0_35 : index to %c8_34 : index step %c1_36 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} -> index
-// KERNEL-NEXT:         %6 = neura.counter from %c0_35 : index to %c8_34 : index step %c1_36 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 2 : i32} -> index
-// KERNEL-NEXT:         %7 = neura.counter from %c0_35 : index to %c64_33 : index step %c1_36 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 3 : i32} -> index
+// KERNEL-NEXT:         %c64_25 = arith.constant 64 : index
+// KERNEL-NEXT:         %c8_26 = arith.constant 8 : index
+// KERNEL-NEXT:         %c0_27 = arith.constant 0 : index
+// KERNEL-NEXT:         %c1_28 = arith.constant 1 : index
+// KERNEL-NEXT:         %4 = neura.counter from %c0_27 : index to %c1_28 : index step %c1_28 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} -> index
+// KERNEL-NEXT:         %5 = neura.counter from %c0_27 : index to %c8_26 : index step %c1_28 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} -> index
+// KERNEL-NEXT:         %6 = neura.counter from %c0_27 : index to %c8_26 : index step %c1_28 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 2 : i32} -> index
+// KERNEL-NEXT:         %7 = neura.counter from %c0_27 : index to %c64_25 : index step %c1_28 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 3 : i32} -> index
 // KERNEL-NEXT:         %8 = memref.load %arg3[%4, %7, %5, %6] : memref<1x64x8x8xf32>
 // KERNEL-NEXT:         memref.store %8, %arg4[%4, %5, %6, %7] : memref<1x8x8x64xf32>
 // KERNEL-NEXT:         neura.yield
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x8x8x64xf32>)
+// KERNEL-NEXT:       taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
 // KERNEL-NEXT:     }
 
 
-// STREAM: module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
+// STREAM:      module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:   memref.global "private" constant @__constant_64xf32 : memref<64xf32> = dense<0.000000e+00> {alignment = 64 : i64}
 // STREAM-NEXT:   memref.global "private" constant @__constant_64x3x3x64xf32_0 : memref<64x3x3x64xf32> = dense<-0.0151730878> {alignment = 64 : i64}
 // STREAM-NEXT:   memref.global "private" constant @__constant_64x3x3x64xf32 : memref<64x3x3x64xf32> = dense<0.0197670367> {alignment = 64 : i64}
@@ -300,7 +300,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:     %cst_1 = arith.constant 3.40282347E+38 : f32
 // STREAM-NEXT:     %cst_2 = arith.constant 0.000000e+00 : f32
 // STREAM-NEXT:     %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -312,7 +312,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
 // STREAM-NEXT:     %dependency_write_out_4 = taskflow.task @Task_1 dependency_write_in(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
@@ -342,7 +342,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:       }
 // STREAM-NEXT:       taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_read_out_7:2, %dependency_write_out_8 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // STREAM-NEXT:       affine.for %arg5 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg6 = 0 to 8 {
@@ -363,10 +363,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg1, %arg3 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) writes(%arg3 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %alloc_9 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// STREAM-NEXT:     %dependency_read_out_10, %dependency_write_out_11 = taskflow.task @Task_4_Task_5_fused dependency_read_in(%dependency_write_out_8 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_9 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_9 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
+// STREAM-NEXT:     %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// STREAM-NEXT:     %dependency_read_out, %dependency_write_out_9 = taskflow.task @Task_4_Task_5_fused dependency_read_in(%dependency_write_out_7 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_8 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // STREAM-NEXT:       affine.for %arg5 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg6 = 0 to 64 {
@@ -382,8 +382,8 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:       }
 // STREAM-NEXT:       taskflow.yield reads(%arg1 : memref<1x8x8x64xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %dependency_read_out_13, %dependency_write_out_14 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_9 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
+// STREAM-NEXT:     %dependency_write_out_11 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_9 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_10 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -395,10 +395,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %alloc_15 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// STREAM-NEXT:     %dependency_write_out_16 = taskflow.task @Task_7 dependency_write_in(%alloc_15 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_15 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// STREAM-NEXT:     %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
+// STREAM-NEXT:     %dependency_write_out_13 = taskflow.task @Task_7 dependency_write_in(%alloc_12 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_12 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 10 {
@@ -411,8 +411,8 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:       }
 // STREAM-NEXT:       taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %alloc_17 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %dependency_write_out_18 = taskflow.task @Task_8 dependency_write_in(%alloc_17 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_17 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
+// STREAM-NEXT:     %dependency_write_out_15 = taskflow.task @Task_8 dependency_write_in(%alloc_14 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -425,7 +425,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:       }
 // STREAM-NEXT:       taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_read_out_19:2, %dependency_write_out_20 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_16, %dependency_write_out_18 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_18 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_15, %alloc_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_17 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %dependency_write_out_16 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_13, %dependency_write_out_15 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_15 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_12, %alloc_14 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // STREAM-NEXT:       affine.for %arg5 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg6 = 0 to 8 {
@@ -446,10 +446,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg1, %arg3 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) writes(%arg3 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// STREAM-NEXT:     %dependency_read_out_22:2, %dependency_write_out_23 = taskflow.task @Task_10_Task_11_Task_12_fused_fused dependency_read_in(%dependency_write_out_20, %dependency_read_out : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_21 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_17, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// STREAM-NEXT:     %alloc_17 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// STREAM-NEXT:     %dependency_read_out_18:2, %dependency_write_out_19 = taskflow.task @Task_10_Task_11_Task_12_fused_fused dependency_read_in(%dependency_write_out_16, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_17 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_14, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_17 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>, %arg4: f32, %arg5: f32):
 // STREAM-NEXT:       affine.for %arg6 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg7 = 0 to 64 {
@@ -467,11 +467,11 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:       }
 // STREAM-NEXT:       taskflow.yield reads(%arg1, %arg2 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) writes(%arg3 : memref<1x64x8x8xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     return %dependency_write_out_23 : memref<1x64x8x8xf32>
+// STREAM-NEXT:     return %dependency_write_out_19 : memref<1x64x8x8xf32>
 // STREAM-NEXT:   }
 // STREAM-NEXT: }
 
-// MAP-SPATIAL-TEMPORAL-4x4:      module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
+// MAP-SPATIAL-TEMPORAL-4x4:     module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  memref.global "private" constant @__constant_64xf32 : memref<64xf32> = dense<0.000000e+00> {alignment = 64 : i64}
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  memref.global "private" constant @__constant_64x3x3x64xf32_0 : memref<64x3x3x64xf32> = dense<-0.0151730878> {alignment = 64 : i64}
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  memref.global "private" constant @__constant_64x3x3x64xf32 : memref<64x3x3x64xf32> = dense<0.0197670367> {alignment = 64 : i64}
@@ -481,7 +481,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %cst_1 = arith.constant 3.40282347E+38 : f32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %cst_2 = arith.constant 0.000000e+00 : f32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 2 : i32}], write_sram_locations = [{col = 1 : i32, row = 2 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 0 : i32, row = 2 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -497,7 +497,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_4 = taskflow.task @Task_1 dependency_write_in(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
@@ -535,7 +535,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_7:2, %dependency_write_out_8 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -560,10 +560,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg1, %arg3 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_9 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_10, %dependency_write_out_11 = taskflow.task @Task_4 dependency_read_in(%dependency_write_out_8 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_9 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_9 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 1 : i32, row = 3 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_9 = taskflow.task @Task_4 dependency_read_in(%dependency_write_out_7 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 2 : i32, row = 2 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -579,10 +579,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg1 : memref<1x8x8x64xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_13, %dependency_write_out_14 = taskflow.task @Task_5 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_9 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 1 : i32, row = 3 : i32}], write_sram_locations = [{col = 0 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_11 = taskflow.task @Task_5 dependency_read_in(%dependency_write_out_9 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 2 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -600,10 +600,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_15 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_16, %dependency_write_out_17 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_14 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_15 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_12 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_15 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 0 : i32, row = 3 : i32}], write_sram_locations = [{col = 0 : i32, row = 2 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_13 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -619,10 +619,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_18 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_19 = taskflow.task @Task_7 dependency_write_in(%alloc_18 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_18 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_15 = taskflow.task @Task_7 dependency_write_in(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -639,8 +639,8 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_20 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_21 = taskflow.task @Task_8 dependency_write_in(%alloc_20 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_20 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_17 = taskflow.task @Task_8 dependency_write_in(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -657,7 +657,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_22:2, %dependency_write_out_23 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_19, %dependency_write_out_21 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_21 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_18, %alloc_20 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_20 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}, {col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_18 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_15, %dependency_write_out_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}, {col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -682,10 +682,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg1, %arg3 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_24 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_25, %dependency_write_out_26 = taskflow.task @Task_10 dependency_read_in(%dependency_write_out_23 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_24 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_20 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_24 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 2 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_20 = taskflow.task @Task_10 dependency_read_in(%dependency_write_out_18 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 3 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -701,10 +701,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg1 : memref<1x8x8x64xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_27 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_28:2, %dependency_write_out_29 = taskflow.task @Task_11 dependency_read_in(%dependency_write_out_26, %dependency_read_out : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_27 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_24, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_27 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 3 : i32, row = 2 : i32}, {col = 2 : i32, row = 2 : i32}], write_sram_locations = [{col = 3 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_22 = taskflow.task @Task_11 dependency_read_in(%dependency_write_out_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 3 : i32, row = 3 : i32}, {col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -722,10 +722,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg3[%arg4, %arg5, %arg6, %arg7] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg1, %arg2 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) writes(%arg3 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg3 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_30 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_read_out_31, %dependency_write_out_32 = taskflow.task @Task_12 dependency_read_in(%dependency_write_out_29 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_30 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_27 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_30 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 3 : i32, row = 3 : i32}], write_sram_locations = [{col = 3 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_23 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_24 = taskflow.task @Task_12 dependency_read_in(%dependency_write_out_22 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 1 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -743,13 +743,13 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return %dependency_write_out_32 : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return %dependency_write_out_24 : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:}
 
-// MAP-SPATIAL-TEMPORAL-1x1:      module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
+// MAP-SPATIAL-TEMPORAL-1x1:     module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  memref.global "private" constant @__constant_64xf32 : memref<64xf32> = dense<0.000000e+00> {alignment = 64 : i64}
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  memref.global "private" constant @__constant_64x3x3x64xf32_0 : memref<64x3x3x64xf32> = dense<-0.0151730878> {alignment = 64 : i64}
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  memref.global "private" constant @__constant_64x3x3x64xf32 : memref<64x3x3x64xf32> = dense<0.0197670367> {alignment = 64 : i64}
@@ -759,7 +759,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %cst_1 = arith.constant 3.40282347E+38 : f32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %cst_2 = arith.constant 0.000000e+00 : f32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 10 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -775,7 +775,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_4 = taskflow.task @Task_1 dependency_write_in(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
@@ -813,7 +813,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_7:2, %dependency_write_out_8 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -838,10 +838,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg1, %arg3 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_9 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_10, %dependency_write_out_11 = taskflow.task @Task_4 dependency_read_in(%dependency_write_out_8 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_9 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_9 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 7 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_9 = taskflow.task @Task_4 dependency_read_in(%dependency_write_out_7 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -857,10 +857,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg1 : memref<1x8x8x64xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_13, %dependency_write_out_14 = taskflow.task @Task_5 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_9 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 9 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_11 = taskflow.task @Task_5 dependency_read_in(%dependency_write_out_9 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 8 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -878,10 +878,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_15 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_16, %dependency_write_out_17 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_14 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_15 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_12 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_15 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 11 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_13 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 11 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -897,10 +897,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_18 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_19 = taskflow.task @Task_7 dependency_write_in(%alloc_18 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_18 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_15 = taskflow.task @Task_7 dependency_write_in(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -917,8 +917,8 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_20 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_21 = taskflow.task @Task_8 dependency_write_in(%alloc_20 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_20 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_17 = taskflow.task @Task_8 dependency_write_in(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -935,7 +935,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_22:2, %dependency_write_out_23 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_19, %dependency_write_out_21 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_21 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_18, %alloc_20 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_20 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_18 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_15, %dependency_write_out_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -960,10 +960,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg1, %arg3 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_24 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_25, %dependency_write_out_26 = taskflow.task @Task_10 dependency_read_in(%dependency_write_out_23 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_24 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_20 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_24 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 8 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_20 = taskflow.task @Task_10 dependency_read_in(%dependency_write_out_18 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 7 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -979,10 +979,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg1 : memref<1x8x8x64xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_27 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_28:2, %dependency_write_out_29 = taskflow.task @Task_11 dependency_read_in(%dependency_write_out_26, %dependency_read_out : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_27 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_24, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_27 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 10 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_22 = taskflow.task @Task_11 dependency_read_in(%dependency_write_out_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 9 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -1000,10 +1000,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg3[%arg4, %arg5, %arg6, %arg7] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg1, %arg2 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) writes(%arg3 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg3 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_30 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_read_out_31, %dependency_write_out_32 = taskflow.task @Task_12 dependency_read_in(%dependency_write_out_29 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_30 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_27 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_30 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 12 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_23 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_24 = taskflow.task @Task_12 dependency_read_in(%dependency_write_out_22 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 12 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -1021,13 +1021,13 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return %dependency_write_out_32 : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return %dependency_write_out_24 : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:}
 
-// MAP-SPATIAL-TEMPORAL-1x2:      module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
+// MAP-SPATIAL-TEMPORAL-1x2:     module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  memref.global "private" constant @__constant_64xf32 : memref<64xf32> = dense<0.000000e+00> {alignment = 64 : i64}
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  memref.global "private" constant @__constant_64x3x3x64xf32_0 : memref<64x3x3x64xf32> = dense<-0.0151730878> {alignment = 64 : i64}
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  memref.global "private" constant @__constant_64x3x3x64xf32 : memref<64x3x3x64xf32> = dense<0.0197670367> {alignment = 64 : i64}
@@ -1037,7 +1037,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %cst_1 = arith.constant 3.40282347E+38 : f32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %cst_2 = arith.constant 0.000000e+00 : f32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1053,10 +1053,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_4 = taskflow.task @Task_1 dependency_write_in(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_4 = taskflow.task @Task_1 dependency_write_in(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1074,7 +1074,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_6 = taskflow.task @Task_2 dependency_write_in(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_6 = taskflow.task @Task_2 dependency_write_in(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1091,7 +1091,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_7:2, %dependency_write_out_8 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1116,10 +1116,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg1, %arg3 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_9 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_10, %dependency_write_out_11 = taskflow.task @Task_4 dependency_read_in(%dependency_write_out_8 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_9 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_9 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_9 = taskflow.task @Task_4 dependency_read_in(%dependency_write_out_7 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1135,10 +1135,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg1 : memref<1x8x8x64xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_13, %dependency_write_out_14 = taskflow.task @Task_5 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_9 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_11 = taskflow.task @Task_5 dependency_read_in(%dependency_write_out_9 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1156,10 +1156,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_15 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_16, %dependency_write_out_17 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_14 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_15 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_12 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_15 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_13 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1175,10 +1175,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_18 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_19 = taskflow.task @Task_7 dependency_write_in(%alloc_18 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_18 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_15 = taskflow.task @Task_7 dependency_write_in(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1195,8 +1195,8 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_20 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_21 = taskflow.task @Task_8 dependency_write_in(%alloc_20 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_20 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_17 = taskflow.task @Task_8 dependency_write_in(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1213,7 +1213,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_22:2, %dependency_write_out_23 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_19, %dependency_write_out_21 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_21 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_18, %alloc_20 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_20 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_18 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_15, %dependency_write_out_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1238,10 +1238,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg1, %arg3 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_24 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_25, %dependency_write_out_26 = taskflow.task @Task_10 dependency_read_in(%dependency_write_out_23 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_24 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_20 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_24 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_20 = taskflow.task @Task_10 dependency_read_in(%dependency_write_out_18 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1257,10 +1257,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg1 : memref<1x8x8x64xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_27 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_28:2, %dependency_write_out_29 = taskflow.task @Task_11 dependency_read_in(%dependency_write_out_26, %dependency_read_out : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_27 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_24, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_27 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_22 = taskflow.task @Task_11 dependency_read_in(%dependency_write_out_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1278,10 +1278,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg3[%arg4, %arg5, %arg6, %arg7] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg1, %arg2 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) writes(%arg3 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg3 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_30 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_read_out_31, %dependency_write_out_32 = taskflow.task @Task_12 dependency_read_in(%dependency_write_out_29 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_30 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_27 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_30 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_23 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_24 = taskflow.task @Task_12 dependency_read_in(%dependency_write_out_22 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1299,13 +1299,13 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return %dependency_write_out_32 : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return %dependency_write_out_24 : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:}
 
-// RESOPT:      %dependency_read_out, %dependency_write_out:3 = taskflow.task @Task_1_Task_0_Task_2_utilfused_utilfused dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 5 : i32, profile_info = {duration = 3 : i32}, trip_count = 6400 : i32} : (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// RESOPT:          %dependency_read_out, %dependency_write_out:3 = taskflow.task @Task_1_Task_0_Task_2_utilfused_utilfused dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 5 : i32, profile_info = {duration = 3 : i32}, trip_count = 6400 : i32} : (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
 // RESOPT-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x10x10x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: memref<1x8x8x64xf32>, %arg5: f32):
 // RESOPT-NEXT:       %c64 = arith.constant 64 : index
 // RESOPT-NEXT:       %c10 = arith.constant 10 : index
@@ -1337,21 +1337,21 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // RESOPT-NEXT:         neura.store_indexed %22 to %22[%23, %24, %25, %26 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<1x8x8x64xf32>, i1> {lhs_value = "%input0"} : !neura.data<memref<1x8x8x64xf32>, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       %c64_20 = arith.constant 64 : index
+// RESOPT-NEXT:       %c64_18 = arith.constant 64 : index
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
-// RESOPT-NEXT:       %c0_21 = arith.constant 0 : index
-// RESOPT-NEXT:       %c1_22 = arith.constant 1 : index
-// RESOPT-NEXT:       %4 = taskflow.counter from %c0_21 to %c1_22 step %c1_22 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
-// RESOPT-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_21 to %c8 step %c1_22 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       %6 = taskflow.counter parent(%5 : index) from %c0_21 to %c8 step %c1_22 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 2 : i32} : index
-// RESOPT-NEXT:       %7 = taskflow.counter parent(%6 : index) from %c0_21 to %c64_20 step %c1_22 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 3 : i32} : index
-// RESOPT-NEXT:       %c64_23 = arith.constant 64 : index
-// RESOPT-NEXT:       %c8_24 = arith.constant 8 : index
-// RESOPT-NEXT:       %c0_25 = arith.constant 0 : index
-// RESOPT-NEXT:       %c1_26 = arith.constant 1 : index
-// RESOPT-NEXT:       %8 = taskflow.counter from %c0_25 to %c1_26 step %c1_26 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
-// RESOPT-NEXT:       %9 = taskflow.counter parent(%8 : index) from %c0_25 to %c8_24 step %c1_26 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       %10 = taskflow.counter parent(%9 : index) from %c0_25 to %c8_24 step %c1_26 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 2 : i32} : index
-// RESOPT-NEXT:       %11 = taskflow.counter parent(%10 : index) from %c0_25 to %c64_23 step %c1_26 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 3 : i32} : index
+// RESOPT-NEXT:       %c0_19 = arith.constant 0 : index
+// RESOPT-NEXT:       %c1_20 = arith.constant 1 : index
+// RESOPT-NEXT:       %4 = taskflow.counter from %c0_19 to %c1_20 step %c1_20 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
+// RESOPT-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_19 to %c8 step %c1_20 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
+// RESOPT-NEXT:       %6 = taskflow.counter parent(%5 : index) from %c0_19 to %c8 step %c1_20 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 2 : i32} : index
+// RESOPT-NEXT:       %7 = taskflow.counter parent(%6 : index) from %c0_19 to %c64_18 step %c1_20 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 3 : i32} : index
+// RESOPT-NEXT:       %c64_21 = arith.constant 64 : index
+// RESOPT-NEXT:       %c8_22 = arith.constant 8 : index
+// RESOPT-NEXT:       %c0_23 = arith.constant 0 : index
+// RESOPT-NEXT:       %c1_24 = arith.constant 1 : index
+// RESOPT-NEXT:       %8 = taskflow.counter from %c0_23 to %c1_24 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
+// RESOPT-NEXT:       %9 = taskflow.counter parent(%8 : index) from %c0_23 to %c8_22 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
+// RESOPT-NEXT:       %10 = taskflow.counter parent(%9 : index) from %c0_23 to %c8_22 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 2 : i32} : index
+// RESOPT-NEXT:       %11 = taskflow.counter parent(%10 : index) from %c0_23 to %c64_21 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 3 : i32} : index
 // RESOPT-NEXT:       taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2, %arg3, %arg4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)
 // RESOPT-NEXT:     }

--- a/test/multi-cgra/taskflow/symbol-dynamic/conv1d/conv1d.mlir
+++ b/test/multi-cgra/taskflow/symbol-dynamic/conv1d/conv1d.mlir
@@ -36,7 +36,7 @@
 // AFFINE-NEXT:       }
 // AFFINE-NEXT:     }
 
-// TASKFLOW:          %dependency_read_out:3, %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg0, %0, %dependency_write_out : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) dependency_write_in(%dependency_write_out : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>) {
+// TASKFLOW:          %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg0, %0, %dependency_write_out : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) dependency_write_in(%dependency_write_out : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg1: memref<1x1x?xf32>, %arg2: memref<16x1x3xf32>, %arg3: memref<1x16x?xf32>, %arg4: memref<1x16x?xf32>, %arg5: index):
 // TASKFLOW-NEXT:       affine.for %arg6 = 0 to 1 {
 // TASKFLOW-NEXT:         affine.for %arg7 = 0 to 16 {
@@ -54,10 +54,10 @@
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg1, %arg2, %arg4 : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) writes(%arg4 : memref<1x16x?xf32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg4 : memref<1x16x?xf32>)
 // TASKFLOW-NEXT:     }
 
-// NEURA:      %dependency_read_out:3, %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg0, %0, %dependency_write_out : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) dependency_write_in(%dependency_write_out : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>) {
+// NEURA:      %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg0, %0, %dependency_write_out : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) dependency_write_in(%dependency_write_out : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
 // NEURA-NEXT:     ^bb0(%arg1: memref<1x1x?xf32>, %arg2: memref<16x1x3xf32>, %arg3: memref<1x16x?xf32>, %arg4: memref<1x16x?xf32>, %arg5: index):
 // NEURA-NEXT:       %c3 = arith.constant 3 : index
 // NEURA-NEXT:       %c16 = arith.constant 16 : index
@@ -70,15 +70,15 @@
 // NEURA-NEXT:       %12 = taskflow.counter parent(%11 : index) from %c0 to %c3 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 4 : i32} : index
 // NEURA-NEXT:       neura.kernel inputs(%arg1, %arg2, %arg4, %arg5 : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, index) {
 // NEURA-NEXT:       ^bb0(%arg6: memref<1x1x?xf32>, %arg7: memref<16x1x3xf32>, %arg8: memref<1x16x?xf32>, %arg9: index):
-// NEURA-NEXT:         %c3_22 = arith.constant 3 : index
-// NEURA-NEXT:         %c16_23 = arith.constant 16 : index
-// NEURA-NEXT:         %c0_24 = arith.constant 0 : index
-// NEURA-NEXT:         %c1_25 = arith.constant 1 : index
-// NEURA-NEXT:         %13 = neura.counter from %c0_24 : index to %c1_25 : index step %c1_25 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} -> index
-// NEURA-NEXT:         %14 = neura.counter from %c0_24 : index to %c16_23 : index step %c1_25 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} -> index
-// NEURA-NEXT:         %15 = neura.counter from %c0_24 : index to %arg9 : index step %c1_25 : index attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "relay", counter_id = 2 : i32} -> index
-// NEURA-NEXT:         %16 = neura.counter from %c0_24 : index to %c1_25 : index step %c1_25 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 3 : i32} -> index
-// NEURA-NEXT:         %17 = neura.counter from %c0_24 : index to %c3_22 : index step %c1_25 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 4 : i32} -> index
+// NEURA-NEXT:         %c3_15 = arith.constant 3 : index
+// NEURA-NEXT:         %c16_16 = arith.constant 16 : index
+// NEURA-NEXT:         %c0_17 = arith.constant 0 : index
+// NEURA-NEXT:         %c1_18 = arith.constant 1 : index
+// NEURA-NEXT:         %13 = neura.counter from %c0_17 : index to %c1_18 : index step %c1_18 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} -> index
+// NEURA-NEXT:         %14 = neura.counter from %c0_17 : index to %c16_16 : index step %c1_18 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} -> index
+// NEURA-NEXT:         %15 = neura.counter from %c0_17 : index to %arg9 : index step %c1_18 : index attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "relay", counter_id = 2 : i32} -> index
+// NEURA-NEXT:         %16 = neura.counter from %c0_17 : index to %c1_18 : index step %c1_18 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 3 : i32} -> index
+// NEURA-NEXT:         %17 = neura.counter from %c0_17 : index to %c3_15 : index step %c1_18 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 4 : i32} -> index
 // NEURA-NEXT:         %18 = arith.addi %15, %17 : index
 // NEURA-NEXT:         %19 = memref.load %arg6[%13, %16, %18] : memref<1x1x?xf32>
 // NEURA-NEXT:         %20 = memref.load %arg7[%14, %16, %17] : memref<16x1x3xf32>
@@ -88,5 +88,5 @@
 // NEURA-NEXT:         memref.store %23, %arg8[%13, %14, %15] : memref<1x16x?xf32>
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield reads(%arg1, %arg2, %arg4 : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) writes(%arg4 : memref<1x16x?xf32>)
+// NEURA-NEXT:       taskflow.yield writes(%arg4 : memref<1x16x?xf32>)
 // NEURA-NEXT:     }

--- a/test/multi-cgra/taskflow/symbol-dynamic/cross_attention/cross_attention.mlir
+++ b/test/multi-cgra/taskflow/symbol-dynamic/cross_attention/cross_attention.mlir
@@ -33,8 +33,7 @@
 // AFFINE-NEXT:       }
 // AFFINE-NEXT:     }
 
-// TASKFLOW:          %dim_7 = memref.dim %arg0, %c0 : memref<?x64xf32>
-// TASKFLOW-NEXT:     %dependency_read_out_8:3, %dependency_write_out_9 = taskflow.task @Task_3 dependency_read_in(%arg0, %dependency_write_out, %dependency_write_out_6 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<?x64xf32>) value_inputs(%dim_7 : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>) {
+// TASKFLOW:          %dependency_read_out_7, %dependency_write_out_8 = taskflow.task @Task_3 dependency_read_in(%arg0, %dependency_write_out, %dependency_write_out_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) dependency_write_in(%dependency_write_out_5 : memref<?x64xf32>) value_inputs(%dim_6 : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg2: memref<?x64xf32>, %arg3: memref<64x64xf32>, %arg4: memref<?x64xf32>, %arg5: memref<?x64xf32>, %arg6: index):
 // TASKFLOW-NEXT:       affine.for %arg7 = 0 to %arg6 {
 // TASKFLOW-NEXT:         affine.for %arg8 = 0 to 64 {
@@ -48,25 +47,25 @@
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg2, %arg3, %arg5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) writes(%arg5 : memref<?x64xf32>)
+// TASKFLOW-NEXT:       taskflow.yield reads(%arg3 : memref<64x64xf32>) writes(%arg5 : memref<?x64xf32>)
 // TASKFLOW-NEXT:     }
 
-// NEURA:      %dependency_read_out_7:3, %dependency_write_out_8 = taskflow.task @Task_3 dependency_read_in(%arg0, %dependency_write_out, %dependency_write_out_6 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<?x64xf32>) value_inputs(%dim : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>) {
+// NEURA:          %dependency_read_out_6, %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%arg0, %dependency_write_out, %dependency_write_out_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) dependency_write_in(%dependency_write_out_5 : memref<?x64xf32>) value_inputs(%dim : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
 // NEURA-NEXT:     ^bb0(%arg2: memref<?x64xf32>, %arg3: memref<64x64xf32>, %arg4: memref<?x64xf32>, %arg5: memref<?x64xf32>, %arg6: index):
 // NEURA-NEXT:       %c64 = arith.constant 64 : index
-// NEURA-NEXT:       %c0_58 = arith.constant 0 : index
+// NEURA-NEXT:       %c0_45 = arith.constant 0 : index
 // NEURA-NEXT:       %c1 = arith.constant 1 : index
-// NEURA-NEXT:       %4 = taskflow.counter from %c0_58 to %arg6 step %c1 attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
-// NEURA-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_58 to %c64 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
-// NEURA-NEXT:       %6 = taskflow.counter parent(%5 : index) from %c0_58 to %c64 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} : index
+// NEURA-NEXT:       %4 = taskflow.counter from %c0_45 to %arg6 step %c1 attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
+// NEURA-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_45 to %c64 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
+// NEURA-NEXT:       %6 = taskflow.counter parent(%5 : index) from %c0_45 to %c64 step %c1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} : index
 // NEURA-NEXT:       neura.kernel inputs(%arg2, %arg3, %arg5, %arg6 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, index) {
 // NEURA-NEXT:       ^bb0(%arg7: memref<?x64xf32>, %arg8: memref<64x64xf32>, %arg9: memref<?x64xf32>, %arg10: index):
-// NEURA-NEXT:         %c64_59 = arith.constant 64 : index
-// NEURA-NEXT:         %c0_60 = arith.constant 0 : index
-// NEURA-NEXT:         %c1_61 = arith.constant 1 : index
-// NEURA-NEXT:         %7 = neura.counter from %c0_60 : index to %arg10 : index step %c1_61 : index attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "root", counter_id = 0 : i32} -> index
-// NEURA-NEXT:         %8 = neura.counter from %c0_60 : index to %c64_59 : index step %c1_61 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} -> index
-// NEURA-NEXT:         %9 = neura.counter from %c0_60 : index to %c64_59 : index step %c1_61 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} -> index
+// NEURA-NEXT:         %c64_46 = arith.constant 64 : index
+// NEURA-NEXT:         %c0_47 = arith.constant 0 : index
+// NEURA-NEXT:         %c1_48 = arith.constant 1 : index
+// NEURA-NEXT:         %7 = neura.counter from %c0_47 : index to %arg10 : index step %c1_48 : index attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "root", counter_id = 0 : i32} -> index
+// NEURA-NEXT:         %8 = neura.counter from %c0_47 : index to %c64_46 : index step %c1_48 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} -> index
+// NEURA-NEXT:         %9 = neura.counter from %c0_47 : index to %c64_46 : index step %c1_48 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} -> index
 // NEURA-NEXT:         %10 = memref.load %arg7[%7, %9] : memref<?x64xf32>
 // NEURA-NEXT:         %11 = memref.load %arg8[%9, %8] : memref<64x64xf32>
 // NEURA-NEXT:         %12 = memref.load %arg9[%7, %8] : memref<?x64xf32>
@@ -75,5 +74,5 @@
 // NEURA-NEXT:         memref.store %14, %arg9[%7, %8] : memref<?x64xf32>
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield reads(%arg2, %arg3, %arg5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) writes(%arg5 : memref<?x64xf32>)
+// NEURA-NEXT:       taskflow.yield reads(%arg3 : memref<64x64xf32>) writes(%arg5 : memref<?x64xf32>)
 // NEURA-NEXT:     }

--- a/test/multi-cgra/taskflow/symbol-dynamic/gcn/gcn.mlir
+++ b/test/multi-cgra/taskflow/symbol-dynamic/gcn/gcn.mlir
@@ -35,7 +35,7 @@
 
 // TASKFLOW:          %dim_2 = memref.dim %arg1, %c0 : memref<?x?xf32>
 // TASKFLOW-NEXT:     %dim_3 = memref.dim %arg1, %c1 : memref<?x?xf32>
-// TASKFLOW-NEXT:     %dependency_read_out:3, %dependency_write_out_4 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg0, %dependency_write_out : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) dependency_write_in(%dependency_write_out : memref<?x8xf32>) value_inputs(%dim_2, %dim_3 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>) {
+// TASKFLOW-NEXT:     %dependency_write_out_4 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg0, %dependency_write_out : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) dependency_write_in(%dependency_write_out : memref<?x8xf32>) value_inputs(%dim_2, %dim_3 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg2: memref<?x?xf32>, %arg3: memref<?x8xf32>, %arg4: memref<?x8xf32>, %arg5: memref<?x8xf32>, %arg6: index, %arg7: index):
 // TASKFLOW-NEXT:       affine.for %arg8 = 0 to %arg6 {
 // TASKFLOW-NEXT:         affine.for %arg9 = 0 to 8 {
@@ -49,25 +49,25 @@
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg2, %arg3, %arg5 : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) writes(%arg5 : memref<?x8xf32>)
+// TASKFLOW-NEXT:       taskflow.yield writes(%arg5 : memref<?x8xf32>)
 // TASKFLOW-NEXT:     }
 
-// NEURA:      %dependency_read_out:3, %dependency_write_out_2 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg0, %dependency_write_out : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) dependency_write_in(%dependency_write_out : memref<?x8xf32>) value_inputs(%dim, %dim_0 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>) {
+// NEURA:          %dependency_write_out_2 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg0, %dependency_write_out : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) dependency_write_in(%dependency_write_out : memref<?x8xf32>) value_inputs(%dim, %dim_0 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
 // NEURA-NEXT:     ^bb0(%arg2: memref<?x?xf32>, %arg3: memref<?x8xf32>, %arg4: memref<?x8xf32>, %arg5: memref<?x8xf32>, %arg6: index, %arg7: index):
 // NEURA-NEXT:       %c8 = arith.constant 8 : index
-// NEURA-NEXT:       %c0_26 = arith.constant 0 : index
-// NEURA-NEXT:       %c1_27 = arith.constant 1 : index
-// NEURA-NEXT:       %4 = taskflow.counter from %c0_26 to %arg6 step %c1_27 attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
-// NEURA-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_26 to %c8 step %c1_27 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
-// NEURA-NEXT:       %6 = taskflow.counter parent(%5 : index) from %c0_26 to %arg7 step %c1_27 attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} : index
+// NEURA-NEXT:       %c0_17 = arith.constant 0 : index
+// NEURA-NEXT:       %c1_18 = arith.constant 1 : index
+// NEURA-NEXT:       %4 = taskflow.counter from %c0_17 to %arg6 step %c1_18 attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
+// NEURA-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_17 to %c8 step %c1_18 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
+// NEURA-NEXT:       %6 = taskflow.counter parent(%5 : index) from %c0_17 to %arg7 step %c1_18 attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} : index
 // NEURA-NEXT:       neura.kernel inputs(%arg2, %arg3, %arg5, %arg6, %arg7 : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) {
 // NEURA-NEXT:       ^bb0(%arg8: memref<?x?xf32>, %arg9: memref<?x8xf32>, %arg10: memref<?x8xf32>, %arg11: index, %arg12: index):
-// NEURA-NEXT:         %c8_28 = arith.constant 8 : index
-// NEURA-NEXT:         %c0_29 = arith.constant 0 : index
-// NEURA-NEXT:         %c1_30 = arith.constant 1 : index
-// NEURA-NEXT:         %7 = neura.counter from %c0_29 : index to %arg11 : index step %c1_30 : index attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "root", counter_id = 0 : i32} -> index
-// NEURA-NEXT:         %8 = neura.counter from %c0_29 : index to %c8_28 : index step %c1_30 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} -> index
-// NEURA-NEXT:         %9 = neura.counter from %c0_29 : index to %arg12 : index step %c1_30 : index attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} -> index
+// NEURA-NEXT:         %c8_19 = arith.constant 8 : index
+// NEURA-NEXT:         %c0_20 = arith.constant 0 : index
+// NEURA-NEXT:         %c1_21 = arith.constant 1 : index
+// NEURA-NEXT:         %7 = neura.counter from %c0_20 : index to %arg11 : index step %c1_21 : index attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "root", counter_id = 0 : i32} -> index
+// NEURA-NEXT:         %8 = neura.counter from %c0_20 : index to %c8_19 : index step %c1_21 : index attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} -> index
+// NEURA-NEXT:         %9 = neura.counter from %c0_20 : index to %arg12 : index step %c1_21 : index attributes {counter_dynamism = "symbol_bound", counter_hierarchy = "leaf", counter_id = 2 : i32} -> index
 // NEURA-NEXT:         %10 = memref.load %arg8[%7, %9] : memref<?x?xf32>
 // NEURA-NEXT:         %11 = memref.load %arg9[%9, %8] : memref<?x8xf32>
 // NEURA-NEXT:         %12 = memref.load %arg10[%7, %8] : memref<?x8xf32>
@@ -76,5 +76,5 @@
 // NEURA-NEXT:         memref.store %14, %arg10[%7, %8] : memref<?x8xf32>
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield reads(%arg2, %arg3, %arg5 : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) writes(%arg5 : memref<?x8xf32>)
+// NEURA-NEXT:       taskflow.yield writes(%arg5 : memref<?x8xf32>)
 // NEURA-NEXT:     }

--- a/test/neura/kernel_fusion/test.mlir
+++ b/test/neura/kernel_fusion/test.mlir
@@ -192,7 +192,7 @@ func.func @test_sibling_rejected_compute(%A: memref<64xf32>,
 // =============================================================================
 
 // CHECK-LABEL: func.func @test_sibling_rejected_memory
-// CHECK:         taskflow.task @fused_sibling
+// CHECK-NOT:         taskflow.task @fused_sibling
 // CHECK:         return
 
 func.func @test_sibling_rejected_memory(%A: memref<64xf32>,


### PR DESCRIPTION
This PR:

1. **Fix false read-read serialization in `AffineToTaskflow`.**

   Previously, the conversion used a single memref value mapping to represent memory dependence states. This could incorrectly serialize two tasks that only read the same memref.

   Conceptually:

   ```text
   T0: read A -> write B
   T1: read A -> write C
   ```

   These two tasks should both read the same current state of `A` and run independently. With the old mapping, `T1` could accidentally consume a read state produced by `T0`, creating a fake edge.

   The pass now separates memory state tracking into latest write states and pending read states. Independent readers consume the same latest write state and do not depend on each other.

2. **Emit `dependency_read_out` only for real WAR dependencies.**

   Previously, every task yielded all read memrefs as `dependency_read_out`, even if no later writer needed that read state.

   Old IR example from `multi-nested.mlir`:

   ```mlir
   %dependency_read_out, %dependency_write_out =
     taskflow.task @Task_0
       dependency_read_in(%arg0 : memref<?x8x6xi32>)
       dependency_write_in(%arg5 : memref<?xi32>)
       ...
       : (memref<?x8x6xi32>, memref<?xi32>)
      -> (memref<?x8x6xi32>, memref<?xi32>) {
     ...
     taskflow.yield reads(%arg10 : memref<?x8x6xi32>)
                    writes(%arg11 : memref<?xi32>)
   }
   ```

   New IR:

   ```mlir
   %dependency_write_out =
     taskflow.task @Task_0
       dependency_read_in(%arg0 : memref<?x8x6xi32>)
       dependency_write_in(%arg5 : memref<?xi32>)
       ...
       : (memref<?x8x6xi32>, memref<?xi32>)
      -> (memref<?xi32>) {
     ...
     taskflow.yield writes(%arg11 : memref<?xi32>)
   }
   ```

   For true WAR cases, the pass still emits sparse read states. For example, in `cross_attention.mlir`, `Task_3` only yields the read state that a later writer must wait on:

   ```mlir
   taskflow.yield reads(%arg3 : memref<64x64xf32>)
                  writes(%arg5 : memref<?x64xf32>)
   ```

   This keeps the IR cleaner while still preserving RAW/WAW/WAR ordering correctly.

The PR also updates `taskflow.task` documentation, parser/printer behavior, and tests to match the new dependence-state semantics.