### PR TITLE
Rename Taskflow memory dependency

### DIFF
--- a/include/TaskflowDialect/TaskflowOps.td
+++ b/include/TaskflowDialect/TaskflowOps.td
@@ -37,7 +37,7 @@ def TaskflowTaskOp
 
     Tasks has two types of inputs/outputs:
     1. Memory dependence states: memref SSA versions that the task reads or
-       writes. A dependency_read_out or dependency_write_out is still the same
+       writes. A done_read or done_write is still the same
        underlying memref, but represents the state after this task has observed
        or modified it.
     2. Value dependencies: SSA values from producer tasks
@@ -50,8 +50,8 @@ def TaskflowTaskOp
     Example:
       // Memory state inputs: %mem_state, %out_state. Value input: %val.
       $out_mem, %out_val = taskflow.task "Task_0"
-        dependency_read_in(%mem_state : memref<4xi32>)
-        dependency_write_in(%out_state : memref<?xi32>)
+        will_read(%mem_state : memref<4xi32>)
+        will_write(%out_state : memref<?xi32>)
         value_inputs(%val : i32)
         [original_read_memrefs(%arg0 : memref<?x8x6xi32>),
          original_write_memrefs(%arg5 : memref<?xi32>)] {
@@ -61,17 +61,17 @@ def TaskflowTaskOp
           %sum = arith.addi %v, %a2 : i32
           affine.store %sum, %a1[%i] : memref<?xi32>
         }
-        taskflow.yield reads(%a0 : memref<4xi32>) writes(%a1 : memref<?xi32>) values(%a2 : i32)
+        taskflow.yield done_read(%a0 : memref<4xi32>) done_write(%a1 : memref<?xi32>) values(%a2 : i32)
       } : (memref<4xi32>, memref<?xi32>, i32) -> (memref<4xi32>, memref<?xi32>, i32)
   }];
 
-  let arguments = (ins Variadic<AnyMemRef>:$dependency_read_in,
-      Variadic<AnyMemRef>:$dependency_write_in, Variadic<AnyType>:$value_inputs,
+  let arguments = (ins Variadic<AnyMemRef>:$will_read,
+      Variadic<AnyMemRef>:$will_write, Variadic<AnyType>:$value_inputs,
       StrAttr:$task_name, Variadic<AnyMemRef>:$original_read_memrefs,
       Variadic<AnyMemRef>:$original_write_memrefs);
 
-  let results = (outs Variadic<AnyMemRef>:$dependency_read_out,
-      Variadic<AnyMemRef>:$dependency_write_out,
+  let results = (outs Variadic<AnyMemRef>:$done_read,
+      Variadic<AnyMemRef>:$done_write,
       Variadic<AnyType>:$value_outputs);
 
   let regions = (region SizedRegion<1>:$body);
@@ -98,8 +98,8 @@ def TaskflowYieldOp
       } : (memref<4xi32>, i32) -> memref<4xi32>
   }];
 
-  let arguments = (ins Variadic<AnyMemRef>:$read_results,
-      Variadic<AnyMemRef>:$memory_results, Variadic<AnyType>:$value_results);
+  let arguments = (ins Variadic<AnyMemRef>:$done_read,
+      Variadic<AnyMemRef>:$done_write, Variadic<AnyType>:$value_results);
 
   let hasCustomAssemblyFormat = 1;
 

--- a/include/TaskflowDialect/TaskflowOps.td
+++ b/include/TaskflowDialect/TaskflowOps.td
@@ -37,9 +37,9 @@ def TaskflowTaskOp
 
     Tasks has two types of inputs/outputs:
     1. Memory dependence states: memref SSA versions that the task reads or
-       writes. A done_read or done_write is still the same
-       underlying memref, but represents the state after this task has observed
-       or modified it.
+       writes. The done_reads and done_writes results still refer to the same
+       underlying memrefs, but represent the states after this task has observed
+       or modified them.
     2. Value dependencies: SSA values from producer tasks
 
     The `original_read_memrefs` and `original_write_memrefs` operands record
@@ -50,8 +50,8 @@ def TaskflowTaskOp
     Example:
       // Memory state inputs: %mem_state, %out_state. Value input: %val.
       $out_mem, %out_val = taskflow.task "Task_0"
-        will_read(%mem_state : memref<4xi32>)
-        will_write(%out_state : memref<?xi32>)
+        will_reads(%mem_state : memref<4xi32>)
+        will_writes(%out_state : memref<?xi32>)
         value_inputs(%val : i32)
         [original_read_memrefs(%arg0 : memref<?x8x6xi32>),
          original_write_memrefs(%arg5 : memref<?xi32>)] {
@@ -61,17 +61,17 @@ def TaskflowTaskOp
           %sum = arith.addi %v, %a2 : i32
           affine.store %sum, %a1[%i] : memref<?xi32>
         }
-        taskflow.yield done_read(%a0 : memref<4xi32>) done_write(%a1 : memref<?xi32>) values(%a2 : i32)
+        taskflow.yield done_reads(%a0 : memref<4xi32>) done_writes(%a1 : memref<?xi32>) values(%a2 : i32)
       } : (memref<4xi32>, memref<?xi32>, i32) -> (memref<4xi32>, memref<?xi32>, i32)
   }];
 
-  let arguments = (ins Variadic<AnyMemRef>:$will_read,
-      Variadic<AnyMemRef>:$will_write, Variadic<AnyType>:$value_inputs,
+  let arguments = (ins Variadic<AnyMemRef>:$will_reads,
+      Variadic<AnyMemRef>:$will_writes, Variadic<AnyType>:$value_inputs,
       StrAttr:$task_name, Variadic<AnyMemRef>:$original_read_memrefs,
       Variadic<AnyMemRef>:$original_write_memrefs);
 
-  let results = (outs Variadic<AnyMemRef>:$done_read,
-      Variadic<AnyMemRef>:$done_write,
+  let results = (outs Variadic<AnyMemRef>:$done_reads,
+      Variadic<AnyMemRef>:$done_writes,
       Variadic<AnyType>:$value_outputs);
 
   let regions = (region SizedRegion<1>:$body);
@@ -92,14 +92,14 @@ def TaskflowYieldOp
     match the result types of the parent taskflow.task operation.
     
     Example:
-      taskflow.task "Task_0" (%arg0, %arg1) {
+      taskflow.task "Task_0" will_reads(%arg0 : memref<4xi32>) value_inputs(%arg1 : i32) {
         ...
-        taskflow.yield %a0 : memref<4xi32>
+        taskflow.yield done_reads(%a0 : memref<4xi32>)
       } : (memref<4xi32>, i32) -> memref<4xi32>
   }];
 
-  let arguments = (ins Variadic<AnyMemRef>:$done_read,
-      Variadic<AnyMemRef>:$done_write, Variadic<AnyType>:$value_results);
+  let arguments = (ins Variadic<AnyMemRef>:$done_reads,
+      Variadic<AnyMemRef>:$done_writes, Variadic<AnyType>:$value_results);
 
   let hasCustomAssemblyFormat = 1;
 

--- a/lib/Conversion/AffineToTaskflow/AffineToTaskflowPass.cpp
+++ b/lib/Conversion/AffineToTaskflow/AffineToTaskflowPass.cpp
@@ -340,15 +340,15 @@ static TaskflowTaskOp convertLoopToTask(
   // Step 8: Creates the yield operation.
   //---------------------------------------------------------------
   task_builder.setInsertionPointToEnd(task_body);
-  SmallVector<Value> yield_for_done_read;
-  SmallVector<Value> yield_for_done_write;
+  SmallVector<Value> yield_for_done_reads;
+  SmallVector<Value> yield_for_done_writes;
   SmallVector<Value> value_yield_operands;
 
   // Read yield outputs: passthrough only sparse read states needed by later
   // writers.
   for (Value memref : read_output_memrefs) {
     if (input_to_block_arg.count(memref)) {
-      yield_for_done_read.push_back(input_to_block_arg[memref]);
+      yield_for_done_reads.push_back(input_to_block_arg[memref]);
     } else {
       assert(false && "Read memref not in inputs!");
     }
@@ -357,7 +357,7 @@ static TaskflowTaskOp convertLoopToTask(
   // Memory yield outputs: yield the written memrefs.
   for (Value memref : output_memrefs) {
     if (input_to_block_arg.count(memref)) {
-      yield_for_done_write.push_back(input_to_block_arg[memref]);
+      yield_for_done_writes.push_back(input_to_block_arg[memref]);
     } else {
       assert(false && "Written memref not in inputs!");
     }
@@ -367,8 +367,8 @@ static TaskflowTaskOp convertLoopToTask(
   for (Value result : cloned_loop->getResults()) {
     value_yield_operands.push_back(result);
   }
-  task_builder.create<TaskflowYieldOp>(loc, yield_for_done_read,
-                                       yield_for_done_write,
+  task_builder.create<TaskflowYieldOp>(loc, yield_for_done_reads,
+                                       yield_for_done_writes,
                                        value_yield_operands);
 
   //-------------------------------------------------------------------
@@ -378,14 +378,14 @@ static TaskflowTaskOp convertLoopToTask(
   // Read outputs: pending WAR states for future writers. These do not update
   // latest_write_out, so later readers of the same memref remain independent.
   for (auto [memref, task_read_output] :
-       llvm::zip(read_output_memrefs, task_op.getDoneRead())) {
+       llvm::zip(read_output_memrefs, task_op.getDoneReads())) {
     pending_read_outs[memref].push_back(task_read_output);
   }
 
   // Memory outputs (write): establishes RAW/WAW dependency chain and consumes
   // pending reads for that memref.
   for (auto [memref, task_output] :
-       llvm::zip(output_memrefs, task_op.getDoneWrite())) {
+       llvm::zip(output_memrefs, task_op.getDoneWrites())) {
     latest_write_out[memref] = task_output;
     pending_read_outs[memref].clear();
   }

--- a/lib/Conversion/AffineToTaskflow/AffineToTaskflowPass.cpp
+++ b/lib/Conversion/AffineToTaskflow/AffineToTaskflowPass.cpp
@@ -340,15 +340,15 @@ static TaskflowTaskOp convertLoopToTask(
   // Step 8: Creates the yield operation.
   //---------------------------------------------------------------
   task_builder.setInsertionPointToEnd(task_body);
-  SmallVector<Value> yield_for_dependency_read_out;
-  SmallVector<Value> yield_for_dependency_write_out;
+  SmallVector<Value> yield_for_done_read;
+  SmallVector<Value> yield_for_done_write;
   SmallVector<Value> value_yield_operands;
 
   // Read yield outputs: passthrough only sparse read states needed by later
   // writers.
   for (Value memref : read_output_memrefs) {
     if (input_to_block_arg.count(memref)) {
-      yield_for_dependency_read_out.push_back(input_to_block_arg[memref]);
+      yield_for_done_read.push_back(input_to_block_arg[memref]);
     } else {
       assert(false && "Read memref not in inputs!");
     }
@@ -357,7 +357,7 @@ static TaskflowTaskOp convertLoopToTask(
   // Memory yield outputs: yield the written memrefs.
   for (Value memref : output_memrefs) {
     if (input_to_block_arg.count(memref)) {
-      yield_for_dependency_write_out.push_back(input_to_block_arg[memref]);
+      yield_for_done_write.push_back(input_to_block_arg[memref]);
     } else {
       assert(false && "Written memref not in inputs!");
     }
@@ -367,8 +367,8 @@ static TaskflowTaskOp convertLoopToTask(
   for (Value result : cloned_loop->getResults()) {
     value_yield_operands.push_back(result);
   }
-  task_builder.create<TaskflowYieldOp>(loc, yield_for_dependency_read_out,
-                                       yield_for_dependency_write_out,
+  task_builder.create<TaskflowYieldOp>(loc, yield_for_done_read,
+                                       yield_for_done_write,
                                        value_yield_operands);
 
   //-------------------------------------------------------------------
@@ -378,14 +378,14 @@ static TaskflowTaskOp convertLoopToTask(
   // Read outputs: pending WAR states for future writers. These do not update
   // latest_write_out, so later readers of the same memref remain independent.
   for (auto [memref, task_read_output] :
-       llvm::zip(read_output_memrefs, task_op.getDependencyReadOut())) {
+       llvm::zip(read_output_memrefs, task_op.getDoneRead())) {
     pending_read_outs[memref].push_back(task_read_output);
   }
 
   // Memory outputs (write): establishes RAW/WAW dependency chain and consumes
   // pending reads for that memref.
   for (auto [memref, task_output] :
-       llvm::zip(output_memrefs, task_op.getDependencyWriteOut())) {
+       llvm::zip(output_memrefs, task_op.getDoneWrite())) {
     latest_write_out[memref] = task_output;
     pending_read_outs[memref].clear();
   }

--- a/lib/TaskflowDialect/Allocation/RoutingCriticalPathAllocation.cpp
+++ b/lib/TaskflowDialect/Allocation/RoutingCriticalPathAllocation.cpp
@@ -212,7 +212,7 @@ public:
 
     // Phase 3: Build explicit task dependency edges. Keep scalar/value SSA
     // dependencies visible through value_inputs, and also scan all operands to
-    // catch taskflow dependency_read_in/dependency_write_in token edges.
+    // catch taskflow will_read/will_write token edges.
     for (auto &consumer_node : task_nodes) {
       for (Value value_input : consumer_node->op.getValueInputs()) {
         addProducerDependency(value_input, consumer_node.get());

--- a/lib/TaskflowDialect/Allocation/RoutingCriticalPathAllocation.cpp
+++ b/lib/TaskflowDialect/Allocation/RoutingCriticalPathAllocation.cpp
@@ -212,7 +212,7 @@ public:
 
     // Phase 3: Build explicit task dependency edges. Keep scalar/value SSA
     // dependencies visible through value_inputs, and also scan all operands to
-    // catch taskflow will_read/will_write token edges.
+    // catch taskflow will_reads/will_writes token edges.
     for (auto &consumer_node : task_nodes) {
       for (Value value_input : consumer_node->op.getValueInputs()) {
         addProducerDependency(value_input, consumer_node.get());

--- a/lib/TaskflowDialect/TaskflowOps.cpp
+++ b/lib/TaskflowDialect/TaskflowOps.cpp
@@ -19,20 +19,19 @@ ParseResult TaskflowTaskOp::parse(OpAsmParser &parser, OperationState &result) {
     result.addAttribute("task_name", task_name);
   }
 
-  // Parses dependency_read_in: dependency_read_in(%arg0, %arg1 : memref<?xi32>,
-  // memref<?xi32>).
+  // Parses will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>).
   SmallVector<OpAsmParser::UnresolvedOperand> read_operands;
   SmallVector<Type> read_types;
-  if (succeeded(parser.parseOptionalKeyword("dependency_read_in"))) {
+  if (succeeded(parser.parseOptionalKeyword("will_read"))) {
     if (parser.parseLParen() || parser.parseOperandList(read_operands) ||
         parser.parseColonTypeList(read_types) || parser.parseRParen())
       return failure();
   }
 
-  // Parses dependency_write_in: dependency_write_in(%arg5 : memref<?xi32>).
+  // Parses will_write(%arg5 : memref<?xi32>).
   SmallVector<OpAsmParser::UnresolvedOperand> write_operands;
   SmallVector<Type> write_types;
-  if (succeeded(parser.parseOptionalKeyword("dependency_write_in"))) {
+  if (succeeded(parser.parseOptionalKeyword("will_write"))) {
     if (parser.parseLParen() || parser.parseOperandList(write_operands) ||
         parser.parseColonTypeList(write_types) || parser.parseRParen())
       return failure();
@@ -133,15 +132,15 @@ ParseResult TaskflowTaskOp::parse(OpAsmParser &parser, OperationState &result) {
            static_cast<int32_t>(original_write_operands.size())}));
 
   // Adds result segment sizes. Read/write outputs are inferred from the
-  // terminator, because multiple dependency_write_in states may map to a
-  // single dependency_write_out state.
+  // terminator, because multiple will_write states may map to a single
+  // done_write state.
   size_t num_read_outputs = 0;
   size_t num_write_outputs = 0;
   if (!body->empty()) {
     if (auto yield_op =
             dyn_cast<TaskflowYieldOp>(body->front().getTerminator())) {
-      num_read_outputs = yield_op.getReadResults().size();
-      num_write_outputs = yield_op.getMemoryResults().size();
+      num_read_outputs = yield_op.getDoneRead().size();
+      num_write_outputs = yield_op.getDoneWrite().size();
     }
   }
 
@@ -172,21 +171,21 @@ void TaskflowTaskOp::print(OpAsmPrinter &printer) {
   // Prints task name.
   printer << " @" << getTaskName();
 
-  // Prints dependency_read_in.
-  if (!getDependencyReadIn().empty()) {
-    printer << " dependency_read_in(";
-    llvm::interleaveComma(getDependencyReadIn(), printer);
+  // Prints will_read.
+  if (!getWillRead().empty()) {
+    printer << " will_read(";
+    llvm::interleaveComma(getWillRead(), printer);
     printer << " : ";
-    llvm::interleaveComma(getDependencyReadIn().getTypes(), printer);
+    llvm::interleaveComma(getWillRead().getTypes(), printer);
     printer << ")";
   }
 
-  // Prints dependency_write_in.
-  if (!getDependencyWriteIn().empty()) {
-    printer << " dependency_write_in(";
-    llvm::interleaveComma(getDependencyWriteIn(), printer);
+  // Prints will_write.
+  if (!getWillWrite().empty()) {
+    printer << " will_write(";
+    llvm::interleaveComma(getWillWrite(), printer);
     printer << " : ";
-    llvm::interleaveComma(getDependencyWriteIn().getTypes(), printer);
+    llvm::interleaveComma(getWillWrite().getTypes(), printer);
     printer << ")";
   }
 
@@ -234,14 +233,14 @@ void TaskflowTaskOp::print(OpAsmPrinter &printer) {
   // Prints function type.
   printer << " : (";
   llvm::interleaveComma(
-      llvm::concat<const Type>(getDependencyReadIn().getTypes(),
-                               getDependencyWriteIn().getTypes(),
+      llvm::concat<const Type>(getWillRead().getTypes(),
+                               getWillWrite().getTypes(),
                                getValueInputs().getTypes()),
       printer);
   printer << ") -> (";
   llvm::interleaveComma(
-      llvm::concat<const Type>(getDependencyReadOut().getTypes(),
-                               getDependencyWriteOut().getTypes(),
+      llvm::concat<const Type>(getDoneRead().getTypes(),
+                               getDoneWrite().getTypes(),
                                getValueOutputs().getTypes()),
       printer);
   printer << ")";
@@ -264,15 +263,15 @@ ParseResult TaskflowYieldOp::parse(OpAsmParser &parser,
   SmallVector<OpAsmParser::UnresolvedOperand> value_operands;
   SmallVector<Type> value_types;
 
-  // Parses reads (WAR dependency passthrough).
-  if (succeeded(parser.parseOptionalKeyword("reads"))) {
+  // Parses done_read (WAR dependency passthrough).
+  if (succeeded(parser.parseOptionalKeyword("done_read"))) {
     if (parser.parseLParen() || parser.parseOperandList(read_operands) ||
         parser.parseColonTypeList(read_types) || parser.parseRParen())
       return failure();
   }
 
-  // Parses writes.
-  if (succeeded(parser.parseOptionalKeyword("writes"))) {
+  // Parses done_write.
+  if (succeeded(parser.parseOptionalKeyword("done_write"))) {
     if (parser.parseLParen() || parser.parseOperandList(write_operands) ||
         parser.parseColonTypeList(write_types) || parser.parseRParen())
       return failure();
@@ -303,19 +302,19 @@ ParseResult TaskflowYieldOp::parse(OpAsmParser &parser,
 }
 
 void TaskflowYieldOp::print(OpAsmPrinter &printer) {
-  if (!getReadResults().empty()) {
-    printer << " reads(";
-    llvm::interleaveComma(getReadResults(), printer);
+  if (!getDoneRead().empty()) {
+    printer << " done_read(";
+    llvm::interleaveComma(getDoneRead(), printer);
     printer << " : ";
-    llvm::interleaveComma(getReadResults().getTypes(), printer);
+    llvm::interleaveComma(getDoneRead().getTypes(), printer);
     printer << ")";
   }
 
-  if (!getMemoryResults().empty()) {
-    printer << " writes(";
-    llvm::interleaveComma(getMemoryResults(), printer);
+  if (!getDoneWrite().empty()) {
+    printer << " done_write(";
+    llvm::interleaveComma(getDoneWrite(), printer);
     printer << " : ";
-    llvm::interleaveComma(getMemoryResults().getTypes(), printer);
+    llvm::interleaveComma(getDoneWrite().getTypes(), printer);
     printer << ")";
   }
 

--- a/lib/TaskflowDialect/TaskflowOps.cpp
+++ b/lib/TaskflowDialect/TaskflowOps.cpp
@@ -19,19 +19,19 @@ ParseResult TaskflowTaskOp::parse(OpAsmParser &parser, OperationState &result) {
     result.addAttribute("task_name", task_name);
   }
 
-  // Parses will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>).
+  // Parses will_reads(%arg0, %arg1 : memref<?xi32>, memref<?xi32>).
   SmallVector<OpAsmParser::UnresolvedOperand> read_operands;
   SmallVector<Type> read_types;
-  if (succeeded(parser.parseOptionalKeyword("will_read"))) {
+  if (succeeded(parser.parseOptionalKeyword("will_reads"))) {
     if (parser.parseLParen() || parser.parseOperandList(read_operands) ||
         parser.parseColonTypeList(read_types) || parser.parseRParen())
       return failure();
   }
 
-  // Parses will_write(%arg5 : memref<?xi32>).
+  // Parses will_writes(%arg5 : memref<?xi32>).
   SmallVector<OpAsmParser::UnresolvedOperand> write_operands;
   SmallVector<Type> write_types;
-  if (succeeded(parser.parseOptionalKeyword("will_write"))) {
+  if (succeeded(parser.parseOptionalKeyword("will_writes"))) {
     if (parser.parseLParen() || parser.parseOperandList(write_operands) ||
         parser.parseColonTypeList(write_types) || parser.parseRParen())
       return failure();
@@ -132,15 +132,15 @@ ParseResult TaskflowTaskOp::parse(OpAsmParser &parser, OperationState &result) {
            static_cast<int32_t>(original_write_operands.size())}));
 
   // Adds result segment sizes. Read/write outputs are inferred from the
-  // terminator, because multiple will_write states may map to a single
-  // done_write state.
+  // terminator, because multiple will_writes states may map to a single
+  // done_writes state.
   size_t num_read_outputs = 0;
   size_t num_write_outputs = 0;
   if (!body->empty()) {
     if (auto yield_op =
             dyn_cast<TaskflowYieldOp>(body->front().getTerminator())) {
-      num_read_outputs = yield_op.getDoneRead().size();
-      num_write_outputs = yield_op.getDoneWrite().size();
+      num_read_outputs = yield_op.getDoneReads().size();
+      num_write_outputs = yield_op.getDoneWrites().size();
     }
   }
 
@@ -171,21 +171,21 @@ void TaskflowTaskOp::print(OpAsmPrinter &printer) {
   // Prints task name.
   printer << " @" << getTaskName();
 
-  // Prints will_read.
-  if (!getWillRead().empty()) {
-    printer << " will_read(";
-    llvm::interleaveComma(getWillRead(), printer);
+  // Prints will_reads.
+  if (!getWillReads().empty()) {
+    printer << " will_reads(";
+    llvm::interleaveComma(getWillReads(), printer);
     printer << " : ";
-    llvm::interleaveComma(getWillRead().getTypes(), printer);
+    llvm::interleaveComma(getWillReads().getTypes(), printer);
     printer << ")";
   }
 
-  // Prints will_write.
-  if (!getWillWrite().empty()) {
-    printer << " will_write(";
-    llvm::interleaveComma(getWillWrite(), printer);
+  // Prints will_writes.
+  if (!getWillWrites().empty()) {
+    printer << " will_writes(";
+    llvm::interleaveComma(getWillWrites(), printer);
     printer << " : ";
-    llvm::interleaveComma(getWillWrite().getTypes(), printer);
+    llvm::interleaveComma(getWillWrites().getTypes(), printer);
     printer << ")";
   }
 
@@ -233,14 +233,14 @@ void TaskflowTaskOp::print(OpAsmPrinter &printer) {
   // Prints function type.
   printer << " : (";
   llvm::interleaveComma(
-      llvm::concat<const Type>(getWillRead().getTypes(),
-                               getWillWrite().getTypes(),
+      llvm::concat<const Type>(getWillReads().getTypes(),
+                               getWillWrites().getTypes(),
                                getValueInputs().getTypes()),
       printer);
   printer << ") -> (";
   llvm::interleaveComma(
-      llvm::concat<const Type>(getDoneRead().getTypes(),
-                               getDoneWrite().getTypes(),
+      llvm::concat<const Type>(getDoneReads().getTypes(),
+                               getDoneWrites().getTypes(),
                                getValueOutputs().getTypes()),
       printer);
   printer << ")";
@@ -263,15 +263,15 @@ ParseResult TaskflowYieldOp::parse(OpAsmParser &parser,
   SmallVector<OpAsmParser::UnresolvedOperand> value_operands;
   SmallVector<Type> value_types;
 
-  // Parses done_read (WAR dependency passthrough).
-  if (succeeded(parser.parseOptionalKeyword("done_read"))) {
+  // Parses done_reads (WAR dependency passthrough).
+  if (succeeded(parser.parseOptionalKeyword("done_reads"))) {
     if (parser.parseLParen() || parser.parseOperandList(read_operands) ||
         parser.parseColonTypeList(read_types) || parser.parseRParen())
       return failure();
   }
 
-  // Parses done_write.
-  if (succeeded(parser.parseOptionalKeyword("done_write"))) {
+  // Parses done_writes.
+  if (succeeded(parser.parseOptionalKeyword("done_writes"))) {
     if (parser.parseLParen() || parser.parseOperandList(write_operands) ||
         parser.parseColonTypeList(write_types) || parser.parseRParen())
       return failure();
@@ -302,19 +302,19 @@ ParseResult TaskflowYieldOp::parse(OpAsmParser &parser,
 }
 
 void TaskflowYieldOp::print(OpAsmPrinter &printer) {
-  if (!getDoneRead().empty()) {
-    printer << " done_read(";
-    llvm::interleaveComma(getDoneRead(), printer);
+  if (!getDoneReads().empty()) {
+    printer << " done_reads(";
+    llvm::interleaveComma(getDoneReads(), printer);
     printer << " : ";
-    llvm::interleaveComma(getDoneRead().getTypes(), printer);
+    llvm::interleaveComma(getDoneReads().getTypes(), printer);
     printer << ")";
   }
 
-  if (!getDoneWrite().empty()) {
-    printer << " done_write(";
-    llvm::interleaveComma(getDoneWrite(), printer);
+  if (!getDoneWrites().empty()) {
+    printer << " done_writes(";
+    llvm::interleaveComma(getDoneWrites(), printer);
     printer << " : ";
-    llvm::interleaveComma(getDoneWrite().getTypes(), printer);
+    llvm::interleaveComma(getDoneWrites().getTypes(), printer);
     printer << ")";
   }
 

--- a/lib/TaskflowDialect/Transforms/ClassifyTaskAndCounterPass.cpp
+++ b/lib/TaskflowDialect/Transforms/ClassifyTaskAndCounterPass.cpp
@@ -138,8 +138,8 @@ static BoundKind classifyCounterBoundValue(Value v, TaskflowTaskOp task_op) {
   }
 
   // Block args layout: [dep_read_in…] [dep_write_in…] [value_inputs…]
-  unsigned num_dep_read = task_op.getDependencyReadIn().size();
-  unsigned num_dep_write = task_op.getDependencyWriteIn().size();
+  unsigned num_dep_read = task_op.getWillRead().size();
+  unsigned num_dep_write = task_op.getWillWrite().size();
   unsigned value_input_start = num_dep_read + num_dep_write;
   unsigned arg_idx = block_arg.getArgNumber();
 

--- a/lib/TaskflowDialect/Transforms/ClassifyTaskAndCounterPass.cpp
+++ b/lib/TaskflowDialect/Transforms/ClassifyTaskAndCounterPass.cpp
@@ -138,8 +138,8 @@ static BoundKind classifyCounterBoundValue(Value v, TaskflowTaskOp task_op) {
   }
 
   // Block args layout: [dep_read_in…] [dep_write_in…] [value_inputs…]
-  unsigned num_dep_read = task_op.getWillRead().size();
-  unsigned num_dep_write = task_op.getWillWrite().size();
+  unsigned num_dep_read = task_op.getWillReads().size();
+  unsigned num_dep_write = task_op.getWillWrites().size();
   unsigned value_input_start = num_dep_read + num_dep_write;
   unsigned arg_idx = block_arg.getArgNumber();
 

--- a/lib/TaskflowDialect/Transforms/FuseTaskPass.cpp
+++ b/lib/TaskflowDialect/Transforms/FuseTaskPass.cpp
@@ -49,15 +49,15 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 // Resolves a value through a task's WAR/RAW dependency chain.
-// If v is a done_read or done_write of the task,
+// If v is a done_reads or done_writes of the task,
 // returns the corresponding input; otherwise returns v unchanged.
 static Value resolveThrough(Value v, TaskflowTaskOp task) {
-  for (unsigned i = 0; i < task.getDoneRead().size(); ++i)
-    if (v == task.getDoneRead()[i])
-      return task.getWillRead()[i];
-  for (unsigned i = 0; i < task.getDoneWrite().size(); ++i)
-    if (v == task.getDoneWrite()[i])
-      return task.getWillWrite()[i];
+  for (unsigned i = 0; i < task.getDoneReads().size(); ++i)
+    if (v == task.getDoneReads()[i])
+      return task.getWillReads()[i];
+  for (unsigned i = 0; i < task.getDoneWrites().size(); ++i)
+    if (v == task.getDoneWrites()[i])
+      return task.getWillWrites()[i];
   return v;
 }
 
@@ -175,11 +175,11 @@ static bool canFuseTasks(TaskflowTaskOp t1, TaskflowTaskOp t2) {
 // Returns true if any write output of the producer feeds the consumer.
 static bool hasProducerConsumerRelation(TaskflowTaskOp producer,
                                         TaskflowTaskOp consumer) {
-  for (Value r : producer.getDoneWrite()) {
-    for (Value in : consumer.getWillRead())
+  for (Value r : producer.getDoneWrites()) {
+    for (Value in : consumer.getWillReads())
       if (r == in)
         return true;
-    for (Value in : consumer.getWillWrite())
+    for (Value in : consumer.getWillWrites())
       if (r == in)
         return true;
   }
@@ -191,18 +191,18 @@ static bool hasProducerConsumerRelation(TaskflowTaskOp producer,
 }
 
 // Returns true if tasks share at least one input with no data dependency.
-// Resolves WAR chains: if t2's input is t1's done_read, traces
+// Resolves WAR chains: if t2's input is t1's done_reads, traces
 // back to the original memref for comparison.
 static bool areSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2) {
   llvm::SmallPtrSet<Value, 8> t1_mem;
-  for (Value v : t1.getWillRead())
+  for (Value v : t1.getWillReads())
     t1_mem.insert(v);
-  for (Value v : t1.getWillWrite())
+  for (Value v : t1.getWillWrites())
     t1_mem.insert(v);
   llvm::SmallPtrSet<Value, 8> t1_val(t1.getValueInputs().begin(),
                                      t1.getValueInputs().end());
   bool share = false;
-  for (Value v : t2.getWillRead()) {
+  for (Value v : t2.getWillReads()) {
     Value resolved = resolveThrough(v, t1);
     if (t1_mem.count(resolved)) {
       share = true;
@@ -210,7 +210,7 @@ static bool areSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2) {
     }
   }
   if (!share)
-    for (Value v : t2.getWillWrite()) {
+    for (Value v : t2.getWillWrites()) {
       Value resolved = resolveThrough(v, t1);
       if (t1_mem.count(resolved)) {
         share = true;
@@ -231,9 +231,9 @@ static bool areSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2) {
 static bool hasInterveningUses(TaskflowTaskOp producer,
                                TaskflowTaskOp consumer) {
   llvm::SmallPtrSet<Value, 8> results;
-  for (Value v : producer.getDoneRead())
+  for (Value v : producer.getDoneReads())
     results.insert(v);
-  for (Value v : producer.getDoneWrite())
+  for (Value v : producer.getDoneWrites())
     results.insert(v);
   for (Value v : producer.getValueOutputs())
     results.insert(v);
@@ -255,10 +255,10 @@ static bool hasInterveningUses(TaskflowTaskOp producer,
 
 // Returns true if all outputs of the task have at most one use.
 static bool hasOnlySingleUseOutputs(TaskflowTaskOp task) {
-  for (Value r : task.getDoneRead())
+  for (Value r : task.getDoneReads())
     if (!r.hasOneUse() && !r.use_empty())
       return false;
-  for (Value r : task.getDoneWrite())
+  for (Value r : task.getDoneWrites())
     if (!r.hasOneUse() && !r.use_empty())
       return false;
   for (Value r : task.getValueOutputs())
@@ -315,11 +315,11 @@ static TaskflowTaskOp fuseProducerConsumerTasks(TaskflowTaskOp producer,
                                                 Value intermediate_memref,
                                                 OpBuilder &builder) {
   Location loc = consumer.getLoc();
-  auto prod_read = producer.getWillRead();
-  auto prod_write = producer.getWillWrite();
+  auto prod_read = producer.getWillReads();
+  auto prod_write = producer.getWillWrites();
   auto prod_val = producer.getValueInputs();
-  auto cons_read = consumer.getWillRead();
-  auto cons_write = consumer.getWillWrite();
+  auto cons_read = consumer.getWillReads();
+  auto cons_write = consumer.getWillWrites();
   auto cons_val = consumer.getValueInputs();
 
   // Collects fused inputs, keeping intermediate in write_memrefs for
@@ -347,7 +347,7 @@ static TaskflowTaskOp fuseProducerConsumerTasks(TaskflowTaskOp producer,
 
   // Write/value output types come from the consumer only.
   SmallVector<Type> write_out_types(
-      consumer.getDoneWrite().getTypes());
+      consumer.getDoneWrites().getTypes());
   SmallVector<Type> val_out_types(consumer.getValueOutputs().getTypes());
 
   SmallVector<Value> orig_reads, orig_writes;
@@ -394,8 +394,8 @@ static TaskflowTaskOp fuseProducerConsumerTasks(TaskflowTaskOp producer,
   // finds which write output index it corresponds to, then gets the matching
   // write memref block arg.
   BlockArgument prod_intermediate_arg = nullptr;
-  for (unsigned i = 0; i < producer.getDoneWrite().size(); ++i)
-    if (producer.getDoneWrite()[i] == intermediate_memref)
+  for (unsigned i = 0; i < producer.getDoneWrites().size(); ++i)
+    if (producer.getDoneWrites()[i] == intermediate_memref)
       prod_intermediate_arg = prod_body.getArgument(prod_read.size() + i);
 
   OpBuilder::InsertionGuard guard(builder);
@@ -575,7 +575,7 @@ static TaskflowTaskOp fuseProducerConsumerTasks(TaskflowTaskOp producer,
     yield_reads.push_back(body->getArgument(i));
 
   SmallVector<Value> yield_mem, yield_val;
-  for (Value v : cons_yield.getDoneWrite())
+  for (Value v : cons_yield.getDoneWrites())
     yield_mem.push_back(mapping.lookupOrDefault(v));
   for (Value v : cons_yield.getValueResults())
     yield_val.push_back(mapping.lookupOrDefault(v));
@@ -596,9 +596,9 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
   // Resolves t2's inputs through t1's WAR chains so that the fused task
   // references original memrefs rather than t1's passthrough results.
   SmallVector<Value> t2_read, t2_write, t2_val;
-  for (Value v : t2.getWillRead())
+  for (Value v : t2.getWillReads())
     t2_read.push_back(resolveThrough(v, t1));
-  for (Value v : t2.getWillWrite())
+  for (Value v : t2.getWillWrites())
     t2_write.push_back(resolveThrough(v, t1));
   for (Value v : t2.getValueInputs())
     t2_val.push_back(resolveThrough(v, t1));
@@ -606,8 +606,8 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
   // Deduplicates inputs across both tasks.
   SmallVector<Value> fused_read, fused_write, fused_val;
   llvm::SmallDenseMap<Value, unsigned> read_idx, write_idx, val_idx;
-  collectUnique(t1.getWillRead(), t2_read, fused_read, read_idx);
-  collectUnique(t1.getWillWrite(), t2_write, fused_write, write_idx);
+  collectUnique(t1.getWillReads(), t2_read, fused_read, read_idx);
+  collectUnique(t1.getWillWrites(), t2_write, fused_write, write_idx);
   collectUnique(t1.getValueInputs(), t2_val, fused_val, val_idx);
 
   // Read output types: passthrough of fused read inputs for WAR tracking.
@@ -617,10 +617,10 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
 
   // Combined write/value output types.
   SmallVector<Type> write_out_types, val_out_types;
-  write_out_types.append(t1.getDoneWrite().getTypes().begin(),
-                         t1.getDoneWrite().getTypes().end());
-  write_out_types.append(t2.getDoneWrite().getTypes().begin(),
-                         t2.getDoneWrite().getTypes().end());
+  write_out_types.append(t1.getDoneWrites().getTypes().begin(),
+                         t1.getDoneWrites().getTypes().end());
+  write_out_types.append(t2.getDoneWrites().getTypes().begin(),
+                         t2.getDoneWrites().getTypes().end());
   val_out_types.append(t1.getValueOutputs().getTypes().begin(),
                        t1.getValueOutputs().getTypes().end());
   val_out_types.append(t2.getValueOutputs().getTypes().begin(),
@@ -656,8 +656,8 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
   // When is_t2 is true, resolves inputs through t1's WAR chains for lookup.
   auto mapBlockArgs = [&](TaskflowTaskOp task, IRMapping &m, bool is_t2) {
     Block &tb = task.getBody().front();
-    auto r = task.getWillRead();
-    auto w = task.getWillWrite();
+    auto r = task.getWillReads();
+    auto w = task.getWillWrites();
     auto v = task.getValueInputs();
     for (unsigned i = 0; i < r.size(); ++i) {
       Value key = is_t2 ? resolveThrough(r[i], t1) : r[i];
@@ -788,11 +788,11 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
     all_reads.push_back(body->getArgument(i));
 
   SmallVector<Value> all_mem, all_val;
-  for (Value v : t1_yield.getDoneWrite())
+  for (Value v : t1_yield.getDoneWrites())
     all_mem.push_back(mapping.lookupOrDefault(v));
   for (Value v : t1_yield.getValueResults())
     all_val.push_back(mapping.lookupOrDefault(v));
-  for (Value v : t2_yield.getDoneWrite())
+  for (Value v : t2_yield.getDoneWrites())
     all_mem.push_back(mapping2.lookupOrDefault(v));
   for (Value v : t2_yield.getValueResults())
     all_val.push_back(mapping2.lookupOrDefault(v));
@@ -1163,7 +1163,7 @@ struct ProducerConsumerTaskFusion : public OpRewritePattern<TaskflowTaskOp> {
         auto def = in.getDefiningOp<TaskflowTaskOp>();
         // Only write outputs represent true producer-consumer (RAW) links.
         // Read outputs are WAR dependency chains and must be skipped.
-        if (!def || !llvm::is_contained(def.getDoneWrite(), in))
+        if (!def || !llvm::is_contained(def.getDoneWrites(), in))
           continue;
         if (!canFuseTasks(def, consumer) || !hasOnlySingleUseOutputs(def) ||
             hasInterveningUses(def, consumer) ||
@@ -1176,41 +1176,41 @@ struct ProducerConsumerTaskFusion : public OpRewritePattern<TaskflowTaskOp> {
       }
       return false;
     };
-    if (!tryFindProducer(consumer.getWillRead()) &&
-        !tryFindProducer(consumer.getWillWrite()))
+    if (!tryFindProducer(consumer.getWillReads()) &&
+        !tryFindProducer(consumer.getWillWrites()))
       return failure();
 
     auto fused =
         fuseProducerConsumerTasks(producer, consumer, intermediate, rewriter);
 
-    // Replaces producer's done_read results.
-    for (unsigned i = 0; i < producer.getDoneRead().size(); ++i) {
-      Value orig_read = producer.getWillRead()[i];
-      for (unsigned j = 0; j < fused.getWillRead().size(); ++j) {
-        if (fused.getWillRead()[j] == orig_read) {
-          producer.getDoneRead()[i].replaceAllUsesWith(
-              fused.getDoneRead()[j]);
+    // Replaces producer's done_reads results.
+    for (unsigned i = 0; i < producer.getDoneReads().size(); ++i) {
+      Value orig_read = producer.getWillReads()[i];
+      for (unsigned j = 0; j < fused.getWillReads().size(); ++j) {
+        if (fused.getWillReads()[j] == orig_read) {
+          producer.getDoneReads()[i].replaceAllUsesWith(
+              fused.getDoneReads()[j]);
           break;
         }
       }
     }
-    // Replaces consumer's done_read results.
-    for (unsigned i = 0; i < consumer.getDoneRead().size(); ++i) {
-      Value orig_read = consumer.getWillRead()[i];
+    // Replaces consumer's done_reads results.
+    for (unsigned i = 0; i < consumer.getDoneReads().size(); ++i) {
+      Value orig_read = consumer.getWillReads()[i];
       if (orig_read == intermediate)
         continue;
       Value resolved = resolveThrough(orig_read, producer);
-      for (unsigned j = 0; j < fused.getWillRead().size(); ++j) {
-        if (fused.getWillRead()[j] == resolved) {
-          consumer.getDoneRead()[i].replaceAllUsesWith(
-              fused.getDoneRead()[j]);
+      for (unsigned j = 0; j < fused.getWillReads().size(); ++j) {
+        if (fused.getWillReads()[j] == resolved) {
+          consumer.getDoneReads()[i].replaceAllUsesWith(
+              fused.getDoneReads()[j]);
           break;
         }
       }
     }
     // Replaces consumer's write and value outputs.
-    for (auto [o, n] : llvm::zip(consumer.getDoneWrite(),
-                                 fused.getDoneWrite()))
+    for (auto [o, n] : llvm::zip(consumer.getDoneWrites(),
+                                 fused.getDoneWrites()))
       o.replaceAllUsesWith(n);
     for (auto [o, n] :
          llvm::zip(consumer.getValueOutputs(), fused.getValueOutputs()))
@@ -1244,40 +1244,40 @@ struct SiblingTaskFusion : public OpRewritePattern<TaskflowTaskOp> {
 
     auto fused = fuseSiblingTasks(t1, t2, rewriter);
 
-    // Replaces done_read for both tasks.
-    for (unsigned i = 0; i < t1.getDoneRead().size(); ++i) {
-      Value orig_read = t1.getWillRead()[i];
-      for (unsigned j = 0; j < fused.getWillRead().size(); ++j) {
-        if (fused.getWillRead()[j] == orig_read) {
-          t1.getDoneRead()[i].replaceAllUsesWith(
-              fused.getDoneRead()[j]);
+    // Replaces done_reads for both tasks.
+    for (unsigned i = 0; i < t1.getDoneReads().size(); ++i) {
+      Value orig_read = t1.getWillReads()[i];
+      for (unsigned j = 0; j < fused.getWillReads().size(); ++j) {
+        if (fused.getWillReads()[j] == orig_read) {
+          t1.getDoneReads()[i].replaceAllUsesWith(
+              fused.getDoneReads()[j]);
           break;
         }
       }
     }
-    for (unsigned i = 0; i < t2.getDoneRead().size(); ++i) {
-      Value orig_read = t2.getWillRead()[i];
+    for (unsigned i = 0; i < t2.getDoneReads().size(); ++i) {
+      Value orig_read = t2.getWillReads()[i];
       Value resolved = resolveThrough(orig_read, t1);
-      for (unsigned j = 0; j < fused.getWillRead().size(); ++j) {
-        if (fused.getWillRead()[j] == resolved) {
-          t2.getDoneRead()[i].replaceAllUsesWith(
-              fused.getDoneRead()[j]);
+      for (unsigned j = 0; j < fused.getWillReads().size(); ++j) {
+        if (fused.getWillReads()[j] == resolved) {
+          t2.getDoneReads()[i].replaceAllUsesWith(
+              fused.getDoneReads()[j]);
           break;
         }
       }
     }
 
-    // Replaces done_write and value_outputs.
-    unsigned t1_wo = t1.getDoneWrite().size();
+    // Replaces done_writes and value_outputs.
+    unsigned t1_wo = t1.getDoneWrites().size();
     unsigned t1_vo = t1.getValueOutputs().size();
     for (unsigned i = 0; i < t1_wo; ++i)
-      t1.getDoneWrite()[i].replaceAllUsesWith(
-          fused.getDoneWrite()[i]);
+      t1.getDoneWrites()[i].replaceAllUsesWith(
+          fused.getDoneWrites()[i]);
     for (unsigned i = 0; i < t1_vo; ++i)
       t1.getValueOutputs()[i].replaceAllUsesWith(fused.getValueOutputs()[i]);
-    for (unsigned i = 0; i < t2.getDoneWrite().size(); ++i)
-      t2.getDoneWrite()[i].replaceAllUsesWith(
-          fused.getDoneWrite()[t1_wo + i]);
+    for (unsigned i = 0; i < t2.getDoneWrites().size(); ++i)
+      t2.getDoneWrites()[i].replaceAllUsesWith(
+          fused.getDoneWrites()[t1_wo + i]);
     for (unsigned i = 0; i < t2.getValueOutputs().size(); ++i)
       t2.getValueOutputs()[i].replaceAllUsesWith(
           fused.getValueOutputs()[t1_vo + i]);

--- a/lib/TaskflowDialect/Transforms/FuseTaskPass.cpp
+++ b/lib/TaskflowDialect/Transforms/FuseTaskPass.cpp
@@ -49,15 +49,15 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 // Resolves a value through a task's WAR/RAW dependency chain.
-// If v is a dependency_read_out or dependency_write_out of the task,
+// If v is a done_read or done_write of the task,
 // returns the corresponding input; otherwise returns v unchanged.
 static Value resolveThrough(Value v, TaskflowTaskOp task) {
-  for (unsigned i = 0; i < task.getDependencyReadOut().size(); ++i)
-    if (v == task.getDependencyReadOut()[i])
-      return task.getDependencyReadIn()[i];
-  for (unsigned i = 0; i < task.getDependencyWriteOut().size(); ++i)
-    if (v == task.getDependencyWriteOut()[i])
-      return task.getDependencyWriteIn()[i];
+  for (unsigned i = 0; i < task.getDoneRead().size(); ++i)
+    if (v == task.getDoneRead()[i])
+      return task.getWillRead()[i];
+  for (unsigned i = 0; i < task.getDoneWrite().size(); ++i)
+    if (v == task.getDoneWrite()[i])
+      return task.getWillWrite()[i];
   return v;
 }
 
@@ -175,11 +175,11 @@ static bool canFuseTasks(TaskflowTaskOp t1, TaskflowTaskOp t2) {
 // Returns true if any write output of the producer feeds the consumer.
 static bool hasProducerConsumerRelation(TaskflowTaskOp producer,
                                         TaskflowTaskOp consumer) {
-  for (Value r : producer.getDependencyWriteOut()) {
-    for (Value in : consumer.getDependencyReadIn())
+  for (Value r : producer.getDoneWrite()) {
+    for (Value in : consumer.getWillRead())
       if (r == in)
         return true;
-    for (Value in : consumer.getDependencyWriteIn())
+    for (Value in : consumer.getWillWrite())
       if (r == in)
         return true;
   }
@@ -191,18 +191,18 @@ static bool hasProducerConsumerRelation(TaskflowTaskOp producer,
 }
 
 // Returns true if tasks share at least one input with no data dependency.
-// Resolves WAR chains: if t2's input is t1's dependency_read_out, traces
+// Resolves WAR chains: if t2's input is t1's done_read, traces
 // back to the original memref for comparison.
 static bool areSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2) {
   llvm::SmallPtrSet<Value, 8> t1_mem;
-  for (Value v : t1.getDependencyReadIn())
+  for (Value v : t1.getWillRead())
     t1_mem.insert(v);
-  for (Value v : t1.getDependencyWriteIn())
+  for (Value v : t1.getWillWrite())
     t1_mem.insert(v);
   llvm::SmallPtrSet<Value, 8> t1_val(t1.getValueInputs().begin(),
                                      t1.getValueInputs().end());
   bool share = false;
-  for (Value v : t2.getDependencyReadIn()) {
+  for (Value v : t2.getWillRead()) {
     Value resolved = resolveThrough(v, t1);
     if (t1_mem.count(resolved)) {
       share = true;
@@ -210,7 +210,7 @@ static bool areSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2) {
     }
   }
   if (!share)
-    for (Value v : t2.getDependencyWriteIn()) {
+    for (Value v : t2.getWillWrite()) {
       Value resolved = resolveThrough(v, t1);
       if (t1_mem.count(resolved)) {
         share = true;
@@ -231,9 +231,9 @@ static bool areSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2) {
 static bool hasInterveningUses(TaskflowTaskOp producer,
                                TaskflowTaskOp consumer) {
   llvm::SmallPtrSet<Value, 8> results;
-  for (Value v : producer.getDependencyReadOut())
+  for (Value v : producer.getDoneRead())
     results.insert(v);
-  for (Value v : producer.getDependencyWriteOut())
+  for (Value v : producer.getDoneWrite())
     results.insert(v);
   for (Value v : producer.getValueOutputs())
     results.insert(v);
@@ -255,10 +255,10 @@ static bool hasInterveningUses(TaskflowTaskOp producer,
 
 // Returns true if all outputs of the task have at most one use.
 static bool hasOnlySingleUseOutputs(TaskflowTaskOp task) {
-  for (Value r : task.getDependencyReadOut())
+  for (Value r : task.getDoneRead())
     if (!r.hasOneUse() && !r.use_empty())
       return false;
-  for (Value r : task.getDependencyWriteOut())
+  for (Value r : task.getDoneWrite())
     if (!r.hasOneUse() && !r.use_empty())
       return false;
   for (Value r : task.getValueOutputs())
@@ -315,11 +315,11 @@ static TaskflowTaskOp fuseProducerConsumerTasks(TaskflowTaskOp producer,
                                                 Value intermediate_memref,
                                                 OpBuilder &builder) {
   Location loc = consumer.getLoc();
-  auto prod_read = producer.getDependencyReadIn();
-  auto prod_write = producer.getDependencyWriteIn();
+  auto prod_read = producer.getWillRead();
+  auto prod_write = producer.getWillWrite();
   auto prod_val = producer.getValueInputs();
-  auto cons_read = consumer.getDependencyReadIn();
-  auto cons_write = consumer.getDependencyWriteIn();
+  auto cons_read = consumer.getWillRead();
+  auto cons_write = consumer.getWillWrite();
   auto cons_val = consumer.getValueInputs();
 
   // Collects fused inputs, keeping intermediate in write_memrefs for
@@ -347,7 +347,7 @@ static TaskflowTaskOp fuseProducerConsumerTasks(TaskflowTaskOp producer,
 
   // Write/value output types come from the consumer only.
   SmallVector<Type> write_out_types(
-      consumer.getDependencyWriteOut().getTypes());
+      consumer.getDoneWrite().getTypes());
   SmallVector<Type> val_out_types(consumer.getValueOutputs().getTypes());
 
   SmallVector<Value> orig_reads, orig_writes;
@@ -394,8 +394,8 @@ static TaskflowTaskOp fuseProducerConsumerTasks(TaskflowTaskOp producer,
   // finds which write output index it corresponds to, then gets the matching
   // write memref block arg.
   BlockArgument prod_intermediate_arg = nullptr;
-  for (unsigned i = 0; i < producer.getDependencyWriteOut().size(); ++i)
-    if (producer.getDependencyWriteOut()[i] == intermediate_memref)
+  for (unsigned i = 0; i < producer.getDoneWrite().size(); ++i)
+    if (producer.getDoneWrite()[i] == intermediate_memref)
       prod_intermediate_arg = prod_body.getArgument(prod_read.size() + i);
 
   OpBuilder::InsertionGuard guard(builder);
@@ -575,7 +575,7 @@ static TaskflowTaskOp fuseProducerConsumerTasks(TaskflowTaskOp producer,
     yield_reads.push_back(body->getArgument(i));
 
   SmallVector<Value> yield_mem, yield_val;
-  for (Value v : cons_yield.getMemoryResults())
+  for (Value v : cons_yield.getDoneWrite())
     yield_mem.push_back(mapping.lookupOrDefault(v));
   for (Value v : cons_yield.getValueResults())
     yield_val.push_back(mapping.lookupOrDefault(v));
@@ -596,9 +596,9 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
   // Resolves t2's inputs through t1's WAR chains so that the fused task
   // references original memrefs rather than t1's passthrough results.
   SmallVector<Value> t2_read, t2_write, t2_val;
-  for (Value v : t2.getDependencyReadIn())
+  for (Value v : t2.getWillRead())
     t2_read.push_back(resolveThrough(v, t1));
-  for (Value v : t2.getDependencyWriteIn())
+  for (Value v : t2.getWillWrite())
     t2_write.push_back(resolveThrough(v, t1));
   for (Value v : t2.getValueInputs())
     t2_val.push_back(resolveThrough(v, t1));
@@ -606,8 +606,8 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
   // Deduplicates inputs across both tasks.
   SmallVector<Value> fused_read, fused_write, fused_val;
   llvm::SmallDenseMap<Value, unsigned> read_idx, write_idx, val_idx;
-  collectUnique(t1.getDependencyReadIn(), t2_read, fused_read, read_idx);
-  collectUnique(t1.getDependencyWriteIn(), t2_write, fused_write, write_idx);
+  collectUnique(t1.getWillRead(), t2_read, fused_read, read_idx);
+  collectUnique(t1.getWillWrite(), t2_write, fused_write, write_idx);
   collectUnique(t1.getValueInputs(), t2_val, fused_val, val_idx);
 
   // Read output types: passthrough of fused read inputs for WAR tracking.
@@ -617,10 +617,10 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
 
   // Combined write/value output types.
   SmallVector<Type> write_out_types, val_out_types;
-  write_out_types.append(t1.getDependencyWriteOut().getTypes().begin(),
-                         t1.getDependencyWriteOut().getTypes().end());
-  write_out_types.append(t2.getDependencyWriteOut().getTypes().begin(),
-                         t2.getDependencyWriteOut().getTypes().end());
+  write_out_types.append(t1.getDoneWrite().getTypes().begin(),
+                         t1.getDoneWrite().getTypes().end());
+  write_out_types.append(t2.getDoneWrite().getTypes().begin(),
+                         t2.getDoneWrite().getTypes().end());
   val_out_types.append(t1.getValueOutputs().getTypes().begin(),
                        t1.getValueOutputs().getTypes().end());
   val_out_types.append(t2.getValueOutputs().getTypes().begin(),
@@ -656,8 +656,8 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
   // When is_t2 is true, resolves inputs through t1's WAR chains for lookup.
   auto mapBlockArgs = [&](TaskflowTaskOp task, IRMapping &m, bool is_t2) {
     Block &tb = task.getBody().front();
-    auto r = task.getDependencyReadIn();
-    auto w = task.getDependencyWriteIn();
+    auto r = task.getWillRead();
+    auto w = task.getWillWrite();
     auto v = task.getValueInputs();
     for (unsigned i = 0; i < r.size(); ++i) {
       Value key = is_t2 ? resolveThrough(r[i], t1) : r[i];
@@ -788,11 +788,11 @@ static TaskflowTaskOp fuseSiblingTasks(TaskflowTaskOp t1, TaskflowTaskOp t2,
     all_reads.push_back(body->getArgument(i));
 
   SmallVector<Value> all_mem, all_val;
-  for (Value v : t1_yield.getMemoryResults())
+  for (Value v : t1_yield.getDoneWrite())
     all_mem.push_back(mapping.lookupOrDefault(v));
   for (Value v : t1_yield.getValueResults())
     all_val.push_back(mapping.lookupOrDefault(v));
-  for (Value v : t2_yield.getMemoryResults())
+  for (Value v : t2_yield.getDoneWrite())
     all_mem.push_back(mapping2.lookupOrDefault(v));
   for (Value v : t2_yield.getValueResults())
     all_val.push_back(mapping2.lookupOrDefault(v));
@@ -1163,7 +1163,7 @@ struct ProducerConsumerTaskFusion : public OpRewritePattern<TaskflowTaskOp> {
         auto def = in.getDefiningOp<TaskflowTaskOp>();
         // Only write outputs represent true producer-consumer (RAW) links.
         // Read outputs are WAR dependency chains and must be skipped.
-        if (!def || !llvm::is_contained(def.getDependencyWriteOut(), in))
+        if (!def || !llvm::is_contained(def.getDoneWrite(), in))
           continue;
         if (!canFuseTasks(def, consumer) || !hasOnlySingleUseOutputs(def) ||
             hasInterveningUses(def, consumer) ||
@@ -1176,41 +1176,41 @@ struct ProducerConsumerTaskFusion : public OpRewritePattern<TaskflowTaskOp> {
       }
       return false;
     };
-    if (!tryFindProducer(consumer.getDependencyReadIn()) &&
-        !tryFindProducer(consumer.getDependencyWriteIn()))
+    if (!tryFindProducer(consumer.getWillRead()) &&
+        !tryFindProducer(consumer.getWillWrite()))
       return failure();
 
     auto fused =
         fuseProducerConsumerTasks(producer, consumer, intermediate, rewriter);
 
-    // Replaces producer's dependency_read_out results.
-    for (unsigned i = 0; i < producer.getDependencyReadOut().size(); ++i) {
-      Value orig_read = producer.getDependencyReadIn()[i];
-      for (unsigned j = 0; j < fused.getDependencyReadIn().size(); ++j) {
-        if (fused.getDependencyReadIn()[j] == orig_read) {
-          producer.getDependencyReadOut()[i].replaceAllUsesWith(
-              fused.getDependencyReadOut()[j]);
+    // Replaces producer's done_read results.
+    for (unsigned i = 0; i < producer.getDoneRead().size(); ++i) {
+      Value orig_read = producer.getWillRead()[i];
+      for (unsigned j = 0; j < fused.getWillRead().size(); ++j) {
+        if (fused.getWillRead()[j] == orig_read) {
+          producer.getDoneRead()[i].replaceAllUsesWith(
+              fused.getDoneRead()[j]);
           break;
         }
       }
     }
-    // Replaces consumer's dependency_read_out results.
-    for (unsigned i = 0; i < consumer.getDependencyReadOut().size(); ++i) {
-      Value orig_read = consumer.getDependencyReadIn()[i];
+    // Replaces consumer's done_read results.
+    for (unsigned i = 0; i < consumer.getDoneRead().size(); ++i) {
+      Value orig_read = consumer.getWillRead()[i];
       if (orig_read == intermediate)
         continue;
       Value resolved = resolveThrough(orig_read, producer);
-      for (unsigned j = 0; j < fused.getDependencyReadIn().size(); ++j) {
-        if (fused.getDependencyReadIn()[j] == resolved) {
-          consumer.getDependencyReadOut()[i].replaceAllUsesWith(
-              fused.getDependencyReadOut()[j]);
+      for (unsigned j = 0; j < fused.getWillRead().size(); ++j) {
+        if (fused.getWillRead()[j] == resolved) {
+          consumer.getDoneRead()[i].replaceAllUsesWith(
+              fused.getDoneRead()[j]);
           break;
         }
       }
     }
     // Replaces consumer's write and value outputs.
-    for (auto [o, n] : llvm::zip(consumer.getDependencyWriteOut(),
-                                 fused.getDependencyWriteOut()))
+    for (auto [o, n] : llvm::zip(consumer.getDoneWrite(),
+                                 fused.getDoneWrite()))
       o.replaceAllUsesWith(n);
     for (auto [o, n] :
          llvm::zip(consumer.getValueOutputs(), fused.getValueOutputs()))
@@ -1244,40 +1244,40 @@ struct SiblingTaskFusion : public OpRewritePattern<TaskflowTaskOp> {
 
     auto fused = fuseSiblingTasks(t1, t2, rewriter);
 
-    // Replaces dependency_read_out for both tasks.
-    for (unsigned i = 0; i < t1.getDependencyReadOut().size(); ++i) {
-      Value orig_read = t1.getDependencyReadIn()[i];
-      for (unsigned j = 0; j < fused.getDependencyReadIn().size(); ++j) {
-        if (fused.getDependencyReadIn()[j] == orig_read) {
-          t1.getDependencyReadOut()[i].replaceAllUsesWith(
-              fused.getDependencyReadOut()[j]);
+    // Replaces done_read for both tasks.
+    for (unsigned i = 0; i < t1.getDoneRead().size(); ++i) {
+      Value orig_read = t1.getWillRead()[i];
+      for (unsigned j = 0; j < fused.getWillRead().size(); ++j) {
+        if (fused.getWillRead()[j] == orig_read) {
+          t1.getDoneRead()[i].replaceAllUsesWith(
+              fused.getDoneRead()[j]);
           break;
         }
       }
     }
-    for (unsigned i = 0; i < t2.getDependencyReadOut().size(); ++i) {
-      Value orig_read = t2.getDependencyReadIn()[i];
+    for (unsigned i = 0; i < t2.getDoneRead().size(); ++i) {
+      Value orig_read = t2.getWillRead()[i];
       Value resolved = resolveThrough(orig_read, t1);
-      for (unsigned j = 0; j < fused.getDependencyReadIn().size(); ++j) {
-        if (fused.getDependencyReadIn()[j] == resolved) {
-          t2.getDependencyReadOut()[i].replaceAllUsesWith(
-              fused.getDependencyReadOut()[j]);
+      for (unsigned j = 0; j < fused.getWillRead().size(); ++j) {
+        if (fused.getWillRead()[j] == resolved) {
+          t2.getDoneRead()[i].replaceAllUsesWith(
+              fused.getDoneRead()[j]);
           break;
         }
       }
     }
 
-    // Replaces dependency_write_out and value_outputs.
-    unsigned t1_wo = t1.getDependencyWriteOut().size();
+    // Replaces done_write and value_outputs.
+    unsigned t1_wo = t1.getDoneWrite().size();
     unsigned t1_vo = t1.getValueOutputs().size();
     for (unsigned i = 0; i < t1_wo; ++i)
-      t1.getDependencyWriteOut()[i].replaceAllUsesWith(
-          fused.getDependencyWriteOut()[i]);
+      t1.getDoneWrite()[i].replaceAllUsesWith(
+          fused.getDoneWrite()[i]);
     for (unsigned i = 0; i < t1_vo; ++i)
       t1.getValueOutputs()[i].replaceAllUsesWith(fused.getValueOutputs()[i]);
-    for (unsigned i = 0; i < t2.getDependencyWriteOut().size(); ++i)
-      t2.getDependencyWriteOut()[i].replaceAllUsesWith(
-          fused.getDependencyWriteOut()[t1_wo + i]);
+    for (unsigned i = 0; i < t2.getDoneWrite().size(); ++i)
+      t2.getDoneWrite()[i].replaceAllUsesWith(
+          fused.getDoneWrite()[t1_wo + i]);
     for (unsigned i = 0; i < t2.getValueOutputs().size(); ++i)
       t2.getValueOutputs()[i].replaceAllUsesWith(
           fused.getValueOutputs()[t1_vo + i]);

--- a/lib/TaskflowDialect/Transforms/Optimizations/MemoryAccessStreamingFusion.cpp
+++ b/lib/TaskflowDialect/Transforms/Optimizations/MemoryAccessStreamingFusion.cpp
@@ -105,12 +105,12 @@ private:
   void extractMemrefAccesses(taskflow::TaskflowTaskOp task_op,
                              TaskInfo &task_info) {
     // Extracts read memrefs from the task operands.
-    for (Value memref : task_op.getWillRead()) {
+    for (Value memref : task_op.getWillReads()) {
       task_info.read_memrefs.push_back(memref);
     }
 
     // Extracts write memrefs from the task operands.
-    for (Value memref : task_op.getWillWrite()) {
+    for (Value memref : task_op.getWillWrites()) {
       task_info.write_memrefs.push_back(memref);
     }
 
@@ -146,10 +146,10 @@ private:
     for (auto task_op : tasks) {
       auto &task_info = task_map[task_op.getOperation()];
       // Map read_outputs for WAR dependency tracking.
-      for (Value ro : task_op.getDoneRead()) {
+      for (Value ro : task_op.getDoneReads()) {
         write_output_to_producer[ro] = &task_info;
       }
-      for (Value wo : task_op.getDoneWrite()) {
+      for (Value wo : task_op.getDoneWrites()) {
         write_output_to_producer[wo] = &task_info;
       }
     }
@@ -178,12 +178,12 @@ private:
       };
 
       // RAW: read_memrefs consuming a write_outputs value.
-      for (Value operand : task_op.getWillRead()) {
+      for (Value operand : task_op.getWillReads()) {
         addDependencyIfProduced(operand);
       }
 
       // WAW/WAR: write_memrefs consuming a write_outputs value.
-      for (Value operand : task_op.getWillWrite()) {
+      for (Value operand : task_op.getWillWrites()) {
         addDependencyIfProduced(operand);
       }
     }
@@ -443,7 +443,7 @@ public:
     for (Value v : fused_read_memrefs) {
       read_output_types.push_back(v.getType());
     }
-    for (Value v : reader_op.getDoneWrite()) {
+    for (Value v : reader_op.getDoneWrites()) {
       write_output_types.push_back(v.getType());
     }
     for (Value v : reader_op.getValueOutputs()) {
@@ -492,7 +492,7 @@ private:
 
     // read_memrefs = writer.reads ∪ reader.reads - intermediate
     DenseSet<Value> seen;
-    auto writer_reads = writer_op.getWillRead();
+    auto writer_reads = writer_op.getWillReads();
     auto writer_orig_reads = writer_op.getOriginalReadMemrefs();
     for (unsigned i = 0; i < writer_reads.size(); ++i) {
       Value orig = (i < writer_orig_reads.size()) ? writer_orig_reads[i]
@@ -502,7 +502,7 @@ private:
       }
     }
 
-    auto reader_reads = reader_op.getWillRead();
+    auto reader_reads = reader_op.getWillReads();
     auto reader_orig_reads = reader_op.getOriginalReadMemrefs();
     for (unsigned i = 0; i < reader_reads.size(); ++i) {
       Value orig = (i < reader_orig_reads.size()) ? reader_orig_reads[i]
@@ -514,7 +514,7 @@ private:
 
     // write_memrefs = reader.writes ∪ (writer.writes - intermediate)
     seen.clear();
-    auto reader_writes = reader_op.getWillWrite();
+    auto reader_writes = reader_op.getWillWrites();
     auto reader_orig_writes = reader_op.getOriginalWriteMemrefs();
     for (unsigned i = 0; i < reader_writes.size(); ++i) {
       Value orig = (i < reader_orig_writes.size()) ? reader_orig_writes[i]
@@ -524,7 +524,7 @@ private:
       }
     }
 
-    auto writer_writes = writer_op.getWillWrite();
+    auto writer_writes = writer_op.getWillWrites();
     auto writer_orig_writes = writer_op.getOriginalWriteMemrefs();
     for (unsigned i = 0; i < writer_writes.size(); ++i) {
       Value orig = (i < writer_orig_writes.size()) ? writer_orig_writes[i]
@@ -739,8 +739,8 @@ private:
         // contain SSA results, not the raw alloc.
         if (auto block_arg = dyn_cast<BlockArgument>(load_memref)) {
           unsigned arg_num = block_arg.getArgNumber();
-          unsigned total_reads = reader_op.getWillRead().size();
-          unsigned total_writes = reader_op.getWillWrite().size();
+          unsigned total_reads = reader_op.getWillReads().size();
+          unsigned total_writes = reader_op.getWillWrites().size();
 
           if (arg_num < total_reads) {
             // Use original_read_memrefs to check against intermediate.
@@ -797,7 +797,7 @@ private:
     }
 
     // Maps reader yield's memory results to fused block args.
-    for (Value v : reader_yield.getDoneWrite()) {
+    for (Value v : reader_yield.getDoneWrites()) {
       if (reader_mapping.contains(v)) {
         yield_writes.push_back(reader_mapping.lookup(v));
       } else {
@@ -826,8 +826,8 @@ private:
                     ArrayRef<Value> fused_values) {
 
     unsigned orig_arg_idx = 0;
-    unsigned num_reads = task_op.getWillRead().size();
-    unsigned num_writes = task_op.getWillWrite().size();
+    unsigned num_reads = task_op.getWillReads().size();
+    unsigned num_writes = task_op.getWillWrites().size();
     unsigned num_values = task_op.getValueInputs().size();
 
     // Maps read_memrefs block args.
@@ -837,14 +837,14 @@ private:
     for (unsigned i = 0; i < num_reads; ++i) {
       Value orig_memref = (i < orig_reads.size())
                               ? orig_reads[i]
-                              : task_op.getWillRead()[i];
+                              : task_op.getWillReads()[i];
       if (orig_memref == intermediate) {
         // Intermediate memref — no corresponding fused arg. Skip.
         orig_arg_idx++;
         continue;
       }
       // Finds the fused block arg for this outer memref.
-      Value outer_memref = task_op.getWillRead()[i];
+      Value outer_memref = task_op.getWillReads()[i];
       int fused_idx = findInFusedArgs(outer_memref, fused_reads, fused_writes,
                                       fused_values);
       if (fused_idx >= 0) {
@@ -859,12 +859,12 @@ private:
     for (unsigned i = 0; i < num_writes; ++i) {
       Value orig_memref = (i < orig_writes.size())
                               ? orig_writes[i]
-                              : task_op.getWillWrite()[i];
+                              : task_op.getWillWrites()[i];
       if (orig_memref == intermediate) {
         orig_arg_idx++;
         continue;
       }
-      Value outer_memref = task_op.getWillWrite()[i];
+      Value outer_memref = task_op.getWillWrites()[i];
       int fused_idx = findInFusedArgs(outer_memref, fused_reads, fused_writes,
                                       fused_values);
       if (fused_idx >= 0) {
@@ -941,8 +941,8 @@ private:
 
     // Helper: finds the index of an outer memref in fused_reads.
     auto findInFusedReads = [&](Value outer_memref) -> int {
-      for (unsigned i = 0; i < fused_task.getWillRead().size(); ++i) {
-        if (fused_task.getWillRead()[i] == outer_memref)
+      for (unsigned i = 0; i < fused_task.getWillReads().size(); ++i) {
+        if (fused_task.getWillReads()[i] == outer_memref)
           return i;
       }
       return -1;
@@ -951,34 +951,34 @@ private:
     // Replaces writer's read_outputs: map each to the fused task's
     // corresponding read_output by finding the writer's read_memref
     // in the fused task's read_memrefs.
-    for (unsigned i = 0; i < writer_op.getDoneRead().size(); ++i) {
-      Value writer_read_input = writer_op.getWillRead()[i];
+    for (unsigned i = 0; i < writer_op.getDoneReads().size(); ++i) {
+      Value writer_read_input = writer_op.getWillReads()[i];
       int fused_idx = findInFusedReads(writer_read_input);
       if (fused_idx >= 0) {
-        writer_op.getDoneRead()[i].replaceAllUsesWith(
-            fused_task.getDoneRead()[fused_idx]);
+        writer_op.getDoneReads()[i].replaceAllUsesWith(
+            fused_task.getDoneReads()[fused_idx]);
       }
     }
 
     // Replaces reader's read_outputs: skip intermediate, map others.
-    for (unsigned i = 0; i < reader_op.getDoneRead().size(); ++i) {
+    for (unsigned i = 0; i < reader_op.getDoneReads().size(); ++i) {
       Value orig = (i < reader_op.getOriginalReadMemrefs().size())
                        ? reader_op.getOriginalReadMemrefs()[i]
-                       : reader_op.getWillRead()[i];
+                       : reader_op.getWillReads()[i];
       if (orig == intermediate)
         continue; // Intermediate read_output is dead after fusion.
-      Value reader_read_input = reader_op.getWillRead()[i];
+      Value reader_read_input = reader_op.getWillReads()[i];
       int fused_idx = findInFusedReads(reader_read_input);
       if (fused_idx >= 0) {
-        reader_op.getDoneRead()[i].replaceAllUsesWith(
-            fused_task.getDoneRead()[fused_idx]);
+        reader_op.getDoneReads()[i].replaceAllUsesWith(
+            fused_task.getDoneReads()[fused_idx]);
       }
     }
 
     // Replaces reader's write_outputs with fused task's write_outputs.
-    for (unsigned i = 0; i < reader_op.getDoneWrite().size(); ++i) {
-      reader_op.getDoneWrite()[i].replaceAllUsesWith(
-          fused_task.getDoneWrite()[i]);
+    for (unsigned i = 0; i < reader_op.getDoneWrites().size(); ++i) {
+      reader_op.getDoneWrites()[i].replaceAllUsesWith(
+          fused_task.getDoneWrites()[i]);
     }
 
     // Replaces reader's value_outputs with fused task's value_outputs.

--- a/lib/TaskflowDialect/Transforms/Optimizations/MemoryAccessStreamingFusion.cpp
+++ b/lib/TaskflowDialect/Transforms/Optimizations/MemoryAccessStreamingFusion.cpp
@@ -105,12 +105,12 @@ private:
   void extractMemrefAccesses(taskflow::TaskflowTaskOp task_op,
                              TaskInfo &task_info) {
     // Extracts read memrefs from the task operands.
-    for (Value memref : task_op.getDependencyReadIn()) {
+    for (Value memref : task_op.getWillRead()) {
       task_info.read_memrefs.push_back(memref);
     }
 
     // Extracts write memrefs from the task operands.
-    for (Value memref : task_op.getDependencyWriteIn()) {
+    for (Value memref : task_op.getWillWrite()) {
       task_info.write_memrefs.push_back(memref);
     }
 
@@ -146,10 +146,10 @@ private:
     for (auto task_op : tasks) {
       auto &task_info = task_map[task_op.getOperation()];
       // Map read_outputs for WAR dependency tracking.
-      for (Value ro : task_op.getDependencyReadOut()) {
+      for (Value ro : task_op.getDoneRead()) {
         write_output_to_producer[ro] = &task_info;
       }
-      for (Value wo : task_op.getDependencyWriteOut()) {
+      for (Value wo : task_op.getDoneWrite()) {
         write_output_to_producer[wo] = &task_info;
       }
     }
@@ -178,12 +178,12 @@ private:
       };
 
       // RAW: read_memrefs consuming a write_outputs value.
-      for (Value operand : task_op.getDependencyReadIn()) {
+      for (Value operand : task_op.getWillRead()) {
         addDependencyIfProduced(operand);
       }
 
       // WAW/WAR: write_memrefs consuming a write_outputs value.
-      for (Value operand : task_op.getDependencyWriteIn()) {
+      for (Value operand : task_op.getWillWrite()) {
         addDependencyIfProduced(operand);
       }
     }
@@ -443,7 +443,7 @@ public:
     for (Value v : fused_read_memrefs) {
       read_output_types.push_back(v.getType());
     }
-    for (Value v : reader_op.getDependencyWriteOut()) {
+    for (Value v : reader_op.getDoneWrite()) {
       write_output_types.push_back(v.getType());
     }
     for (Value v : reader_op.getValueOutputs()) {
@@ -492,7 +492,7 @@ private:
 
     // read_memrefs = writer.reads ∪ reader.reads - intermediate
     DenseSet<Value> seen;
-    auto writer_reads = writer_op.getDependencyReadIn();
+    auto writer_reads = writer_op.getWillRead();
     auto writer_orig_reads = writer_op.getOriginalReadMemrefs();
     for (unsigned i = 0; i < writer_reads.size(); ++i) {
       Value orig = (i < writer_orig_reads.size()) ? writer_orig_reads[i]
@@ -502,7 +502,7 @@ private:
       }
     }
 
-    auto reader_reads = reader_op.getDependencyReadIn();
+    auto reader_reads = reader_op.getWillRead();
     auto reader_orig_reads = reader_op.getOriginalReadMemrefs();
     for (unsigned i = 0; i < reader_reads.size(); ++i) {
       Value orig = (i < reader_orig_reads.size()) ? reader_orig_reads[i]
@@ -514,7 +514,7 @@ private:
 
     // write_memrefs = reader.writes ∪ (writer.writes - intermediate)
     seen.clear();
-    auto reader_writes = reader_op.getDependencyWriteIn();
+    auto reader_writes = reader_op.getWillWrite();
     auto reader_orig_writes = reader_op.getOriginalWriteMemrefs();
     for (unsigned i = 0; i < reader_writes.size(); ++i) {
       Value orig = (i < reader_orig_writes.size()) ? reader_orig_writes[i]
@@ -524,7 +524,7 @@ private:
       }
     }
 
-    auto writer_writes = writer_op.getDependencyWriteIn();
+    auto writer_writes = writer_op.getWillWrite();
     auto writer_orig_writes = writer_op.getOriginalWriteMemrefs();
     for (unsigned i = 0; i < writer_writes.size(); ++i) {
       Value orig = (i < writer_orig_writes.size()) ? writer_orig_writes[i]
@@ -739,8 +739,8 @@ private:
         // contain SSA results, not the raw alloc.
         if (auto block_arg = dyn_cast<BlockArgument>(load_memref)) {
           unsigned arg_num = block_arg.getArgNumber();
-          unsigned total_reads = reader_op.getDependencyReadIn().size();
-          unsigned total_writes = reader_op.getDependencyWriteIn().size();
+          unsigned total_reads = reader_op.getWillRead().size();
+          unsigned total_writes = reader_op.getWillWrite().size();
 
           if (arg_num < total_reads) {
             // Use original_read_memrefs to check against intermediate.
@@ -797,7 +797,7 @@ private:
     }
 
     // Maps reader yield's memory results to fused block args.
-    for (Value v : reader_yield.getMemoryResults()) {
+    for (Value v : reader_yield.getDoneWrite()) {
       if (reader_mapping.contains(v)) {
         yield_writes.push_back(reader_mapping.lookup(v));
       } else {
@@ -826,8 +826,8 @@ private:
                     ArrayRef<Value> fused_values) {
 
     unsigned orig_arg_idx = 0;
-    unsigned num_reads = task_op.getDependencyReadIn().size();
-    unsigned num_writes = task_op.getDependencyWriteIn().size();
+    unsigned num_reads = task_op.getWillRead().size();
+    unsigned num_writes = task_op.getWillWrite().size();
     unsigned num_values = task_op.getValueInputs().size();
 
     // Maps read_memrefs block args.
@@ -837,14 +837,14 @@ private:
     for (unsigned i = 0; i < num_reads; ++i) {
       Value orig_memref = (i < orig_reads.size())
                               ? orig_reads[i]
-                              : task_op.getDependencyReadIn()[i];
+                              : task_op.getWillRead()[i];
       if (orig_memref == intermediate) {
         // Intermediate memref — no corresponding fused arg. Skip.
         orig_arg_idx++;
         continue;
       }
       // Finds the fused block arg for this outer memref.
-      Value outer_memref = task_op.getDependencyReadIn()[i];
+      Value outer_memref = task_op.getWillRead()[i];
       int fused_idx = findInFusedArgs(outer_memref, fused_reads, fused_writes,
                                       fused_values);
       if (fused_idx >= 0) {
@@ -859,12 +859,12 @@ private:
     for (unsigned i = 0; i < num_writes; ++i) {
       Value orig_memref = (i < orig_writes.size())
                               ? orig_writes[i]
-                              : task_op.getDependencyWriteIn()[i];
+                              : task_op.getWillWrite()[i];
       if (orig_memref == intermediate) {
         orig_arg_idx++;
         continue;
       }
-      Value outer_memref = task_op.getDependencyWriteIn()[i];
+      Value outer_memref = task_op.getWillWrite()[i];
       int fused_idx = findInFusedArgs(outer_memref, fused_reads, fused_writes,
                                       fused_values);
       if (fused_idx >= 0) {
@@ -941,8 +941,8 @@ private:
 
     // Helper: finds the index of an outer memref in fused_reads.
     auto findInFusedReads = [&](Value outer_memref) -> int {
-      for (unsigned i = 0; i < fused_task.getDependencyReadIn().size(); ++i) {
-        if (fused_task.getDependencyReadIn()[i] == outer_memref)
+      for (unsigned i = 0; i < fused_task.getWillRead().size(); ++i) {
+        if (fused_task.getWillRead()[i] == outer_memref)
           return i;
       }
       return -1;
@@ -951,34 +951,34 @@ private:
     // Replaces writer's read_outputs: map each to the fused task's
     // corresponding read_output by finding the writer's read_memref
     // in the fused task's read_memrefs.
-    for (unsigned i = 0; i < writer_op.getDependencyReadOut().size(); ++i) {
-      Value writer_read_input = writer_op.getDependencyReadIn()[i];
+    for (unsigned i = 0; i < writer_op.getDoneRead().size(); ++i) {
+      Value writer_read_input = writer_op.getWillRead()[i];
       int fused_idx = findInFusedReads(writer_read_input);
       if (fused_idx >= 0) {
-        writer_op.getDependencyReadOut()[i].replaceAllUsesWith(
-            fused_task.getDependencyReadOut()[fused_idx]);
+        writer_op.getDoneRead()[i].replaceAllUsesWith(
+            fused_task.getDoneRead()[fused_idx]);
       }
     }
 
     // Replaces reader's read_outputs: skip intermediate, map others.
-    for (unsigned i = 0; i < reader_op.getDependencyReadOut().size(); ++i) {
+    for (unsigned i = 0; i < reader_op.getDoneRead().size(); ++i) {
       Value orig = (i < reader_op.getOriginalReadMemrefs().size())
                        ? reader_op.getOriginalReadMemrefs()[i]
-                       : reader_op.getDependencyReadIn()[i];
+                       : reader_op.getWillRead()[i];
       if (orig == intermediate)
         continue; // Intermediate read_output is dead after fusion.
-      Value reader_read_input = reader_op.getDependencyReadIn()[i];
+      Value reader_read_input = reader_op.getWillRead()[i];
       int fused_idx = findInFusedReads(reader_read_input);
       if (fused_idx >= 0) {
-        reader_op.getDependencyReadOut()[i].replaceAllUsesWith(
-            fused_task.getDependencyReadOut()[fused_idx]);
+        reader_op.getDoneRead()[i].replaceAllUsesWith(
+            fused_task.getDoneRead()[fused_idx]);
       }
     }
 
     // Replaces reader's write_outputs with fused task's write_outputs.
-    for (unsigned i = 0; i < reader_op.getDependencyWriteOut().size(); ++i) {
-      reader_op.getDependencyWriteOut()[i].replaceAllUsesWith(
-          fused_task.getDependencyWriteOut()[i]);
+    for (unsigned i = 0; i < reader_op.getDoneWrite().size(); ++i) {
+      reader_op.getDoneWrite()[i].replaceAllUsesWith(
+          fused_task.getDoneWrite()[i]);
     }
 
     // Replaces reader's value_outputs with fused task's value_outputs.

--- a/lib/TaskflowDialect/Transforms/Optimizations/ResourceAwareTaskOptimizationPass.cpp
+++ b/lib/TaskflowDialect/Transforms/Optimizations/ResourceAwareTaskOptimizationPass.cpp
@@ -283,7 +283,7 @@ public:
     // 3. Builds memory edges.
     for (auto &consumer : nodes) {
       // RAW: producer wrote a memref that this task reads.
-      for (Value memref : consumer->op.getWillRead()) {
+      for (Value memref : consumer->op.getWillReads()) {
         if (auto producer_op = memref.getDefiningOp<TaskflowTaskOp>()) {
           if (auto *producer = op_to_node[producer_op.getOperation()]) {
             addEdge(producer, consumer.get());
@@ -291,7 +291,7 @@ public:
         }
       }
       // WAW/WAR: producer wrote or read a memref that this task writes.
-      for (Value memref : consumer->op.getWillWrite()) {
+      for (Value memref : consumer->op.getWillWrites()) {
         if (auto producer_op = memref.getDefiningOp<TaskflowTaskOp>()) {
           if (auto *producer = op_to_node[producer_op.getOperation()]) {
             addEdge(producer, consumer.get());
@@ -1210,11 +1210,11 @@ private:
         }
       }
     };
-    updateLatest(task_a.getWillRead());
-    updateLatest(task_a.getWillWrite());
+    updateLatest(task_a.getWillReads());
+    updateLatest(task_a.getWillWrites());
     updateLatest(task_a.getValueInputs());
-    updateLatest(task_b.getWillRead());
-    updateLatest(task_b.getWillWrite());
+    updateLatest(task_b.getWillReads());
+    updateLatest(task_b.getWillWrites());
     updateLatest(task_b.getValueInputs());
 
     // Inserts right after the latest operand definition.
@@ -1237,10 +1237,10 @@ private:
       }
     };
 
-    addUnique(merged_read_memrefs, task_a.getWillRead());
-    addUnique(merged_read_memrefs, task_b.getWillRead());
-    addUnique(merged_write_memrefs, task_a.getWillWrite());
-    addUnique(merged_write_memrefs, task_b.getWillWrite());
+    addUnique(merged_read_memrefs, task_a.getWillReads());
+    addUnique(merged_read_memrefs, task_b.getWillReads());
+    addUnique(merged_write_memrefs, task_a.getWillWrites());
+    addUnique(merged_write_memrefs, task_b.getWillWrites());
     addUnique(merged_value_inputs, task_a.getValueInputs());
     addUnique(merged_value_inputs, task_b.getValueInputs());
     addUnique(merged_original_read_memrefs, task_a.getOriginalReadMemrefs());
@@ -1286,11 +1286,11 @@ private:
                                    Region &fused_region, IRMapping &mapping) {
       Block &src_entry = orig_task.getBody().front();
       unsigned src_idx = 0;
-      unsigned read_count = orig_task.getWillRead().size();
-      unsigned write_count = orig_task.getWillWrite().size();
+      unsigned read_count = orig_task.getWillReads().size();
+      unsigned write_count = orig_task.getWillWrites().size();
 
       for (unsigned i = 0; i < read_count; ++i) {
-        Value orig_memref = orig_task.getWillRead()[i];
+        Value orig_memref = orig_task.getWillReads()[i];
         auto it = llvm::find(merged_read_memrefs, orig_memref);
         assert(it != merged_read_memrefs.end());
         unsigned fused_idx = std::distance(merged_read_memrefs.begin(), it);
@@ -1300,7 +1300,7 @@ private:
       src_idx += read_count;
 
       for (unsigned i = 0; i < write_count; ++i) {
-        Value orig_memref = orig_task.getWillWrite()[i];
+        Value orig_memref = orig_task.getWillWrites()[i];
         auto it = llvm::find(merged_write_memrefs, orig_memref);
         assert(it != merged_write_memrefs.end());
         unsigned fused_idx = merged_read_memrefs.size() +
@@ -1614,21 +1614,21 @@ private:
                           unsigned value_output_offset) {
     // Read outputs: maps by matching the original read memref to its
     // position in the merged read memrefs list.
-    for (unsigned i = 0; i < orig_task.getDoneRead().size(); ++i) {
-      Value orig_result = orig_task.getDoneRead()[i];
-      Value orig_read = orig_task.getWillRead()[i];
+    for (unsigned i = 0; i < orig_task.getDoneReads().size(); ++i) {
+      Value orig_result = orig_task.getDoneReads()[i];
+      Value orig_read = orig_task.getWillReads()[i];
       unsigned fused_idx = findOperandIndex(merged_read_memrefs, orig_read);
       orig_result.replaceAllUsesWith(
-          fused_task.getDoneRead()[fused_idx]);
+          fused_task.getDoneReads()[fused_idx]);
     }
     // Writes outputs: maps by matching the original write memref to its
     // position in the merged write memrefs list.
-    for (unsigned i = 0; i < orig_task.getDoneWrite().size(); ++i) {
-      Value orig_result = orig_task.getDoneWrite()[i];
-      Value orig_write = orig_task.getWillWrite()[i];
+    for (unsigned i = 0; i < orig_task.getDoneWrites().size(); ++i) {
+      Value orig_result = orig_task.getDoneWrites()[i];
+      Value orig_write = orig_task.getWillWrites()[i];
       unsigned fused_idx = findOperandIndex(merged_write_memrefs, orig_write);
       orig_result.replaceAllUsesWith(
-          fused_task.getDoneWrite()[fused_idx]);
+          fused_task.getDoneWrites()[fused_idx]);
     }
     // Value outputs: each original task's value_output[i] maps to
     // fused_task.getValueOutputs()[value_output_offset + i].

--- a/lib/TaskflowDialect/Transforms/Optimizations/ResourceAwareTaskOptimizationPass.cpp
+++ b/lib/TaskflowDialect/Transforms/Optimizations/ResourceAwareTaskOptimizationPass.cpp
@@ -283,7 +283,7 @@ public:
     // 3. Builds memory edges.
     for (auto &consumer : nodes) {
       // RAW: producer wrote a memref that this task reads.
-      for (Value memref : consumer->op.getDependencyReadIn()) {
+      for (Value memref : consumer->op.getWillRead()) {
         if (auto producer_op = memref.getDefiningOp<TaskflowTaskOp>()) {
           if (auto *producer = op_to_node[producer_op.getOperation()]) {
             addEdge(producer, consumer.get());
@@ -291,7 +291,7 @@ public:
         }
       }
       // WAW/WAR: producer wrote or read a memref that this task writes.
-      for (Value memref : consumer->op.getDependencyWriteIn()) {
+      for (Value memref : consumer->op.getWillWrite()) {
         if (auto producer_op = memref.getDefiningOp<TaskflowTaskOp>()) {
           if (auto *producer = op_to_node[producer_op.getOperation()]) {
             addEdge(producer, consumer.get());
@@ -1210,11 +1210,11 @@ private:
         }
       }
     };
-    updateLatest(task_a.getDependencyReadIn());
-    updateLatest(task_a.getDependencyWriteIn());
+    updateLatest(task_a.getWillRead());
+    updateLatest(task_a.getWillWrite());
     updateLatest(task_a.getValueInputs());
-    updateLatest(task_b.getDependencyReadIn());
-    updateLatest(task_b.getDependencyWriteIn());
+    updateLatest(task_b.getWillRead());
+    updateLatest(task_b.getWillWrite());
     updateLatest(task_b.getValueInputs());
 
     // Inserts right after the latest operand definition.
@@ -1237,10 +1237,10 @@ private:
       }
     };
 
-    addUnique(merged_read_memrefs, task_a.getDependencyReadIn());
-    addUnique(merged_read_memrefs, task_b.getDependencyReadIn());
-    addUnique(merged_write_memrefs, task_a.getDependencyWriteIn());
-    addUnique(merged_write_memrefs, task_b.getDependencyWriteIn());
+    addUnique(merged_read_memrefs, task_a.getWillRead());
+    addUnique(merged_read_memrefs, task_b.getWillRead());
+    addUnique(merged_write_memrefs, task_a.getWillWrite());
+    addUnique(merged_write_memrefs, task_b.getWillWrite());
     addUnique(merged_value_inputs, task_a.getValueInputs());
     addUnique(merged_value_inputs, task_b.getValueInputs());
     addUnique(merged_original_read_memrefs, task_a.getOriginalReadMemrefs());
@@ -1286,11 +1286,11 @@ private:
                                    Region &fused_region, IRMapping &mapping) {
       Block &src_entry = orig_task.getBody().front();
       unsigned src_idx = 0;
-      unsigned read_count = orig_task.getDependencyReadIn().size();
-      unsigned write_count = orig_task.getDependencyWriteIn().size();
+      unsigned read_count = orig_task.getWillRead().size();
+      unsigned write_count = orig_task.getWillWrite().size();
 
       for (unsigned i = 0; i < read_count; ++i) {
-        Value orig_memref = orig_task.getDependencyReadIn()[i];
+        Value orig_memref = orig_task.getWillRead()[i];
         auto it = llvm::find(merged_read_memrefs, orig_memref);
         assert(it != merged_read_memrefs.end());
         unsigned fused_idx = std::distance(merged_read_memrefs.begin(), it);
@@ -1300,7 +1300,7 @@ private:
       src_idx += read_count;
 
       for (unsigned i = 0; i < write_count; ++i) {
-        Value orig_memref = orig_task.getDependencyWriteIn()[i];
+        Value orig_memref = orig_task.getWillWrite()[i];
         auto it = llvm::find(merged_write_memrefs, orig_memref);
         assert(it != merged_write_memrefs.end());
         unsigned fused_idx = merged_read_memrefs.size() +
@@ -1614,21 +1614,21 @@ private:
                           unsigned value_output_offset) {
     // Read outputs: maps by matching the original read memref to its
     // position in the merged read memrefs list.
-    for (unsigned i = 0; i < orig_task.getDependencyReadOut().size(); ++i) {
-      Value orig_result = orig_task.getDependencyReadOut()[i];
-      Value orig_read = orig_task.getDependencyReadIn()[i];
+    for (unsigned i = 0; i < orig_task.getDoneRead().size(); ++i) {
+      Value orig_result = orig_task.getDoneRead()[i];
+      Value orig_read = orig_task.getWillRead()[i];
       unsigned fused_idx = findOperandIndex(merged_read_memrefs, orig_read);
       orig_result.replaceAllUsesWith(
-          fused_task.getDependencyReadOut()[fused_idx]);
+          fused_task.getDoneRead()[fused_idx]);
     }
     // Writes outputs: maps by matching the original write memref to its
     // position in the merged write memrefs list.
-    for (unsigned i = 0; i < orig_task.getDependencyWriteOut().size(); ++i) {
-      Value orig_result = orig_task.getDependencyWriteOut()[i];
-      Value orig_write = orig_task.getDependencyWriteIn()[i];
+    for (unsigned i = 0; i < orig_task.getDoneWrite().size(); ++i) {
+      Value orig_result = orig_task.getDoneWrite()[i];
+      Value orig_write = orig_task.getWillWrite()[i];
       unsigned fused_idx = findOperandIndex(merged_write_memrefs, orig_write);
       orig_result.replaceAllUsesWith(
-          fused_task.getDependencyWriteOut()[fused_idx]);
+          fused_task.getDoneWrite()[fused_idx]);
     }
     // Value outputs: each original task's value_output[i] maps to
     // fused_task.getValueOutputs()[value_output_offset + i].

--- a/test/Conversion/tosa2taskflow/affine-to-taskflow.mlir
+++ b/test/Conversion/tosa2taskflow/affine-to-taskflow.mlir
@@ -16,7 +16,7 @@ module {
 }
 
 // CHECK:        func.func @simple_add(%arg0: memref<16xf32>, %arg1: memref<16xf32>, %arg2: memref<16xf32>) {
-// CHECK-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) will_write(%arg2 : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%arg2 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
+// CHECK-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) will_writes(%arg2 : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%arg2 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
 // CHECK-NEXT:     ^bb0(%arg3: memref<16xf32>, %arg4: memref<16xf32>, %arg5: memref<16xf32>):
 // CHECK-NEXT:       affine.for %arg6 = 0 to 16 {
 // CHECK-NEXT:         %0 = affine.load %arg3[%arg6] : memref<16xf32>
@@ -24,7 +24,7 @@ module {
 // CHECK-NEXT:         %2 = arith.addf %0, %1 : f32
 // CHECK-NEXT:         affine.store %2, %arg5[%arg6] : memref<16xf32>
 // CHECK-NEXT:       }
-// CHECK-NEXT:       taskflow.yield done_write(%arg5 : memref<16xf32>)
+// CHECK-NEXT:       taskflow.yield done_writes(%arg5 : memref<16xf32>)
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/test/Conversion/tosa2taskflow/affine-to-taskflow.mlir
+++ b/test/Conversion/tosa2taskflow/affine-to-taskflow.mlir
@@ -16,7 +16,7 @@ module {
 }
 
 // CHECK:        func.func @simple_add(%arg0: memref<16xf32>, %arg1: memref<16xf32>, %arg2: memref<16xf32>) {
-// CHECK-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) dependency_write_in(%arg2 : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%arg2 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
+// CHECK-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) will_write(%arg2 : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%arg2 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
 // CHECK-NEXT:     ^bb0(%arg3: memref<16xf32>, %arg4: memref<16xf32>, %arg5: memref<16xf32>):
 // CHECK-NEXT:       affine.for %arg6 = 0 to 16 {
 // CHECK-NEXT:         %0 = affine.load %arg3[%arg6] : memref<16xf32>
@@ -24,7 +24,7 @@ module {
 // CHECK-NEXT:         %2 = arith.addf %0, %1 : f32
 // CHECK-NEXT:         affine.store %2, %arg5[%arg6] : memref<16xf32>
 // CHECK-NEXT:       }
-// CHECK-NEXT:       taskflow.yield writes(%arg5 : memref<16xf32>)
+// CHECK-NEXT:       taskflow.yield done_write(%arg5 : memref<16xf32>)
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/test/Conversion/tosa2taskflow/tosa-to-taskflow.mlir
+++ b/test/Conversion/tosa2taskflow/tosa-to-taskflow.mlir
@@ -11,7 +11,7 @@ func.func @simple_add(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16
 
 // CHECK:      func.func @simple_add(%arg0: memref<16xf32>, %arg1: memref<16xf32>) -> memref<16xf32> {
 // CHECK-NEXT:   %alloc = memref.alloc() {alignment = 64 : i64} : memref<16xf32>
-// CHECK-NEXT:   %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) will_write(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
+// CHECK-NEXT:   %done_writes = taskflow.task @Task_0 will_reads(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) will_writes(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
 // CHECK-NEXT:   ^bb0(%arg2: memref<16xf32>, %arg3: memref<16xf32>, %arg4: memref<16xf32>):
 // CHECK-NEXT:     affine.for %arg5 = 0 to 16 {
 // CHECK-NEXT:       %0 = affine.load %arg2[%arg5] : memref<16xf32>
@@ -19,7 +19,7 @@ func.func @simple_add(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16
 // CHECK-NEXT:       %2 = arith.addf %0, %1 : f32
 // CHECK-NEXT:       affine.store %2, %arg4[%arg5] : memref<16xf32>
 // CHECK-NEXT:     }
-// CHECK-NEXT:     taskflow.yield done_write(%arg4 : memref<16xf32>)
+// CHECK-NEXT:     taskflow.yield done_writes(%arg4 : memref<16xf32>)
 // CHECK-NEXT:   }
-// CHECK-NEXT:   return %done_write : memref<16xf32>
+// CHECK-NEXT:   return %done_writes : memref<16xf32>
 // CHECK-NEXT: }

--- a/test/Conversion/tosa2taskflow/tosa-to-taskflow.mlir
+++ b/test/Conversion/tosa2taskflow/tosa-to-taskflow.mlir
@@ -11,7 +11,7 @@ func.func @simple_add(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16
 
 // CHECK:      func.func @simple_add(%arg0: memref<16xf32>, %arg1: memref<16xf32>) -> memref<16xf32> {
 // CHECK-NEXT:   %alloc = memref.alloc() {alignment = 64 : i64} : memref<16xf32>
-// CHECK-NEXT:   %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) dependency_write_in(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
+// CHECK-NEXT:   %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) will_write(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
 // CHECK-NEXT:   ^bb0(%arg2: memref<16xf32>, %arg3: memref<16xf32>, %arg4: memref<16xf32>):
 // CHECK-NEXT:     affine.for %arg5 = 0 to 16 {
 // CHECK-NEXT:       %0 = affine.load %arg2[%arg5] : memref<16xf32>
@@ -19,7 +19,7 @@ func.func @simple_add(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16
 // CHECK-NEXT:       %2 = arith.addf %0, %1 : f32
 // CHECK-NEXT:       affine.store %2, %arg4[%arg5] : memref<16xf32>
 // CHECK-NEXT:     }
-// CHECK-NEXT:     taskflow.yield writes(%arg4 : memref<16xf32>)
+// CHECK-NEXT:     taskflow.yield done_write(%arg4 : memref<16xf32>)
 // CHECK-NEXT:   }
-// CHECK-NEXT:   return %dependency_write_out : memref<16xf32>
+// CHECK-NEXT:   return %done_write : memref<16xf32>
 // CHECK-NEXT: }

--- a/test/e2e/tosa_e2e.mlir
+++ b/test/e2e/tosa_e2e.mlir
@@ -11,7 +11,7 @@ func.func @test_e2e(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf
 
 // CHECK:      func.func @test_e2e(%arg0: memref<16xf32>, %arg1: memref<16xf32>) -> memref<16xf32> {
 // CHECK-NEXT:   %alloc = memref.alloc() {alignment = 64 : i64} : memref<16xf32>
-// CHECK-NEXT:   %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) dependency_write_in(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
+// CHECK-NEXT:   %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) will_write(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
 // CHECK-NEXT:   ^bb0(%arg2: memref<16xf32>, %arg3: memref<16xf32>, %arg4: memref<16xf32>):
 // CHECK-NEXT:     affine.for %arg5 = 0 to 16 {
 // CHECK-NEXT:       %0 = affine.load %arg2[%arg5] : memref<16xf32>
@@ -20,7 +20,7 @@ func.func @test_e2e(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf
 // CHECK-NEXT:       %3 = arith.mulf %2, %2 : f32
 // CHECK-NEXT:       affine.store %3, %arg4[%arg5] : memref<16xf32>
 // CHECK-NEXT:     }
-// CHECK-NEXT:     taskflow.yield writes(%arg4 : memref<16xf32>)
+// CHECK-NEXT:     taskflow.yield done_write(%arg4 : memref<16xf32>)
 // CHECK-NEXT:   }
-// CHECK-NEXT:   return %dependency_write_out : memref<16xf32>
+// CHECK-NEXT:   return %done_write : memref<16xf32>
 // CHECK-NEXT: }

--- a/test/e2e/tosa_e2e.mlir
+++ b/test/e2e/tosa_e2e.mlir
@@ -11,7 +11,7 @@ func.func @test_e2e(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf
 
 // CHECK:      func.func @test_e2e(%arg0: memref<16xf32>, %arg1: memref<16xf32>) -> memref<16xf32> {
 // CHECK-NEXT:   %alloc = memref.alloc() {alignment = 64 : i64} : memref<16xf32>
-// CHECK-NEXT:   %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) will_write(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
+// CHECK-NEXT:   %done_writes = taskflow.task @Task_0 will_reads(%arg0, %arg1 : memref<16xf32>, memref<16xf32>) will_writes(%alloc : memref<16xf32>) [original_read_memrefs(%arg0, %arg1 : memref<16xf32>, memref<16xf32>), original_write_memrefs(%alloc : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, memref<16xf32>) -> (memref<16xf32>) {
 // CHECK-NEXT:   ^bb0(%arg2: memref<16xf32>, %arg3: memref<16xf32>, %arg4: memref<16xf32>):
 // CHECK-NEXT:     affine.for %arg5 = 0 to 16 {
 // CHECK-NEXT:       %0 = affine.load %arg2[%arg5] : memref<16xf32>
@@ -20,7 +20,7 @@ func.func @test_e2e(%arg0: tensor<16xf32>, %arg1: tensor<16xf32>) -> tensor<16xf
 // CHECK-NEXT:       %3 = arith.mulf %2, %2 : f32
 // CHECK-NEXT:       affine.store %3, %arg4[%arg5] : memref<16xf32>
 // CHECK-NEXT:     }
-// CHECK-NEXT:     taskflow.yield done_write(%arg4 : memref<16xf32>)
+// CHECK-NEXT:     taskflow.yield done_writes(%arg4 : memref<16xf32>)
 // CHECK-NEXT:   }
-// CHECK-NEXT:   return %done_write : memref<16xf32>
+// CHECK-NEXT:   return %done_writes : memref<16xf32>
 // CHECK-NEXT: }

--- a/test/multi-cgra/kernel_mapping/fir/fir.mlir
+++ b/test/multi-cgra/kernel_mapping/fir/fir.mlir
@@ -92,7 +92,7 @@ module attributes {} {
 // TASKFLOW: module {
 // TASKFLOW-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // TASKFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// TASKFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// TASKFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // TASKFLOW-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // TASKFLOW-NEXT:       %0 = affine.for %arg6 = 0 to 32 iter_args(%arg7 = %arg5) -> (i32) {
 // TASKFLOW-NEXT:         %1 = affine.load %arg3[%arg6] : memref<?xi32>
@@ -110,7 +110,7 @@ module attributes {} {
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // HYPERBLOCK-NEXT:     %c0_i32 = arith.constant 0 : i32
-// HYPERBLOCK-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// HYPERBLOCK-NEXT:     %value_outputs = taskflow.task @Task_0 will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c32 = arith.constant 32 : index
@@ -133,7 +133,7 @@ module attributes {} {
 // KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // KERNEL-NEXT:     %c0_i32 = arith.constant 0 : i32
-// KERNEL-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// KERNEL-NEXT:     %value_outputs = taskflow.task @Task_0 will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // KERNEL-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // KERNEL-NEXT:       %c0 = arith.constant 0 : index
 // KERNEL-NEXT:       %c32 = arith.constant 32 : index
@@ -160,7 +160,7 @@ module attributes {} {
 // NEURA:      module {
 // NEURA-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // NEURA-NEXT:     %c0_i32 = arith.constant 0 : i32
-// NEURA-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// NEURA-NEXT:     %value_outputs = taskflow.task @Task_0 will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // NEURA-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // NEURA-NEXT:       %c0 = arith.constant 0 : index
 // NEURA-NEXT:       %c32 = arith.constant 32 : index
@@ -187,7 +187,7 @@ module attributes {} {
 // DATAFLOW:      module {
 // DATAFLOW-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // DATAFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// DATAFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// DATAFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // DATAFLOW-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // DATAFLOW-NEXT:       %c0 = arith.constant 0 : index
 // DATAFLOW-NEXT:       %c32 = arith.constant 32 : index
@@ -219,7 +219,7 @@ module attributes {} {
 // MAPPED:      module {
 // MAPPED-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // MAPPED-NEXT:     %c0_i32 = arith.constant 0 : i32
-// MAPPED-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// MAPPED-NEXT:     %value_outputs = taskflow.task @Task_0 will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // MAPPED-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // MAPPED-NEXT:       %c0 = arith.constant 0 : index
 // MAPPED-NEXT:       %c32 = arith.constant 32 : index

--- a/test/multi-cgra/kernel_mapping/fir/fir.mlir
+++ b/test/multi-cgra/kernel_mapping/fir/fir.mlir
@@ -92,7 +92,7 @@ module attributes {} {
 // TASKFLOW: module {
 // TASKFLOW-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // TASKFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// TASKFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// TASKFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // TASKFLOW-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // TASKFLOW-NEXT:       %0 = affine.for %arg6 = 0 to 32 iter_args(%arg7 = %arg5) -> (i32) {
 // TASKFLOW-NEXT:         %1 = affine.load %arg3[%arg6] : memref<?xi32>
@@ -110,7 +110,7 @@ module attributes {} {
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // HYPERBLOCK-NEXT:     %c0_i32 = arith.constant 0 : i32
-// HYPERBLOCK-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// HYPERBLOCK-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c32 = arith.constant 32 : index
@@ -133,7 +133,7 @@ module attributes {} {
 // KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // KERNEL-NEXT:     %c0_i32 = arith.constant 0 : i32
-// KERNEL-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// KERNEL-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // KERNEL-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // KERNEL-NEXT:       %c0 = arith.constant 0 : index
 // KERNEL-NEXT:       %c32 = arith.constant 32 : index
@@ -160,7 +160,7 @@ module attributes {} {
 // NEURA:      module {
 // NEURA-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // NEURA-NEXT:     %c0_i32 = arith.constant 0 : i32
-// NEURA-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// NEURA-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // NEURA-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // NEURA-NEXT:       %c0 = arith.constant 0 : index
 // NEURA-NEXT:       %c32 = arith.constant 32 : index
@@ -187,7 +187,7 @@ module attributes {} {
 // DATAFLOW:      module {
 // DATAFLOW-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // DATAFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// DATAFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// DATAFLOW-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // DATAFLOW-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // DATAFLOW-NEXT:       %c0 = arith.constant 0 : index
 // DATAFLOW-NEXT:       %c32 = arith.constant 32 : index
@@ -219,7 +219,7 @@ module attributes {} {
 // MAPPED:      module {
 // MAPPED-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // MAPPED-NEXT:     %c0_i32 = arith.constant 0 : i32
-// MAPPED-NEXT:     %value_outputs = taskflow.task @Task_0 dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
+// MAPPED-NEXT:     %value_outputs = taskflow.task @Task_0 will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg2 : memref<?xi32>, memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, i32) -> (i32) {
 // MAPPED-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // MAPPED-NEXT:       %c0 = arith.constant 0 : index
 // MAPPED-NEXT:       %c32 = arith.constant 32 : index

--- a/test/multi-cgra/kernel_mapping/loop-in-kernel/loop-in-kernel.mlir
+++ b/test/multi-cgra/kernel_mapping/loop-in-kernel/loop-in-kernel.mlir
@@ -55,7 +55,7 @@
 module {
   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
     %c0_i32 = arith.constant 0 : i32
-    %dependency_read_out:2, %value_outputs = taskflow.task @Task_o dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+    %done_read:2, %value_outputs = taskflow.task @Task_o will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
       %1 = neura.kernel inputs(%arg3, %arg4, %arg5 : memref<?xi32>, memref<?xi32>, i32) {
       ^bb0(%arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: i32):
@@ -68,7 +68,7 @@ module {
         }
         neura.yield results(%0 : i32)
       } : i32
-      taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%1 : i32)
+      taskflow.yield done_read(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%1 : i32)
     }
     return %value_outputs : i32
   }
@@ -77,7 +77,7 @@ module {
 // NEURA: module {
 // NEURA-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // NEURA-NEXT:     %c0_i32 = arith.constant 0 : i32
-// NEURA-NEXT:     %dependency_read_out:2, %value_outputs = taskflow.task @Task_o dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// NEURA-NEXT:     %done_read:2, %value_outputs = taskflow.task @Task_o will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
 // NEURA-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // NEURA-NEXT:       %0 = neura.kernel inputs(%arg3, %arg4, %arg5 : memref<?xi32>, memref<?xi32>, i32) attributes {accelerator = "neura"} {
 // NEURA-NEXT:       ^bb0(%arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: i32):
@@ -101,7 +101,7 @@ module {
 // NEURA-NEXT:       ^bb3:  // pred: ^bb1
 // NEURA-NEXT:         neura.yield results(%6 : i32)
 // NEURA-NEXT:       } : i32
-// NEURA-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
+// NEURA-NEXT:       taskflow.yield done_read(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
 // NEURA-NEXT:     }
 // NEURA-NEXT:     return %value_outputs : i32
 // NEURA-NEXT:   }
@@ -111,7 +111,7 @@ module {
 // DATAFLOW: module {
 // DATAFLOW-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // DATAFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// DATAFLOW-NEXT:     %dependency_read_out:2, %value_outputs = taskflow.task @Task_o dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// DATAFLOW-NEXT:     %done_read:2, %value_outputs = taskflow.task @Task_o will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
 // DATAFLOW-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // DATAFLOW-NEXT:       %0 = neura.kernel inputs(%arg3, %arg4, %arg5 : memref<?xi32>, memref<?xi32>, i32) attributes {accelerator = "neura", dataflow_mode = "predicate"} {
 // DATAFLOW-NEXT:       ^bb0(%arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: i32):
@@ -140,7 +140,7 @@ module {
 // DATAFLOW-NEXT:         neura.ctrl_mov %18 -> %5 : !neura.data<i32, i1> !neura.data<i32, i1>
 // DATAFLOW-NEXT:         neura.yield
 // DATAFLOW-NEXT:       } : i32
-// DATAFLOW-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
+// DATAFLOW-NEXT:       taskflow.yield done_read(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
 // DATAFLOW-NEXT:     }
 // DATAFLOW-NEXT:     return %value_outputs : i32
 // DATAFLOW-NEXT:   }
@@ -150,7 +150,7 @@ module {
 // MAPPED: module {
 // MAPPED-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // MAPPED-NEXT:     %c0_i32 = arith.constant 0 : i32
-// MAPPED-NEXT:     %dependency_read_out:2, %value_outputs = taskflow.task @Task_o dependency_read_in(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// MAPPED-NEXT:     %done_read:2, %value_outputs = taskflow.task @Task_o will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
 // MAPPED-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // MAPPED-NEXT:       %0 = neura.kernel inputs(%arg3, %arg4, %arg5 : memref<?xi32>, memref<?xi32>, i32) attributes {accelerator = "neura", dataflow_mode = "predicate", mapping_info = {compiled_ii = 6 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 4 : i32, res_mii = 1 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
 // MAPPED-NEXT:       ^bb0(%arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: i32):
@@ -193,7 +193,7 @@ module {
 // MAPPED-NEXT:         neura.ctrl_mov %32 -> %3 {dfg_id = 37 : i32, mapping_locs = [{id = 201 : i32, index_per_ii = 1 : i32, invalid_iterations = 1 : i32, per_tile_register_id = 9 : i32, resource = "register", time_step = 7 : i32}, {id = 201 : i32, index_per_ii = 2 : i32, invalid_iterations = 1 : i32, per_tile_register_id = 9 : i32, resource = "register", time_step = 8 : i32}, {id = 201 : i32, index_per_ii = 3 : i32, invalid_iterations = 1 : i32, per_tile_register_id = 9 : i32, resource = "register", time_step = 9 : i32}]} : !neura.data<i32, i1> !neura.data<i32, i1>
 // MAPPED-NEXT:         neura.yield {dfg_id = 4 : i32}
 // MAPPED-NEXT:       } : i32
-// MAPPED-NEXT:       taskflow.yield reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
+// MAPPED-NEXT:       taskflow.yield done_read(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
 // MAPPED-NEXT:     }
 // MAPPED-NEXT:     return %value_outputs : i32
 // MAPPED-NEXT:   }

--- a/test/multi-cgra/kernel_mapping/loop-in-kernel/loop-in-kernel.mlir
+++ b/test/multi-cgra/kernel_mapping/loop-in-kernel/loop-in-kernel.mlir
@@ -55,7 +55,7 @@
 module {
   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
     %c0_i32 = arith.constant 0 : i32
-    %done_read:2, %value_outputs = taskflow.task @Task_o will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+    %done_reads:2, %value_outputs = taskflow.task @Task_o will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
       %1 = neura.kernel inputs(%arg3, %arg4, %arg5 : memref<?xi32>, memref<?xi32>, i32) {
       ^bb0(%arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: i32):
@@ -68,7 +68,7 @@ module {
         }
         neura.yield results(%0 : i32)
       } : i32
-      taskflow.yield done_read(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%1 : i32)
+      taskflow.yield done_reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%1 : i32)
     }
     return %value_outputs : i32
   }
@@ -77,7 +77,7 @@ module {
 // NEURA: module {
 // NEURA-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // NEURA-NEXT:     %c0_i32 = arith.constant 0 : i32
-// NEURA-NEXT:     %done_read:2, %value_outputs = taskflow.task @Task_o will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// NEURA-NEXT:     %done_reads:2, %value_outputs = taskflow.task @Task_o will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
 // NEURA-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // NEURA-NEXT:       %0 = neura.kernel inputs(%arg3, %arg4, %arg5 : memref<?xi32>, memref<?xi32>, i32) attributes {accelerator = "neura"} {
 // NEURA-NEXT:       ^bb0(%arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: i32):
@@ -101,7 +101,7 @@ module {
 // NEURA-NEXT:       ^bb3:  // pred: ^bb1
 // NEURA-NEXT:         neura.yield results(%6 : i32)
 // NEURA-NEXT:       } : i32
-// NEURA-NEXT:       taskflow.yield done_read(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
+// NEURA-NEXT:       taskflow.yield done_reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
 // NEURA-NEXT:     }
 // NEURA-NEXT:     return %value_outputs : i32
 // NEURA-NEXT:   }
@@ -111,7 +111,7 @@ module {
 // DATAFLOW: module {
 // DATAFLOW-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // DATAFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// DATAFLOW-NEXT:     %done_read:2, %value_outputs = taskflow.task @Task_o will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// DATAFLOW-NEXT:     %done_reads:2, %value_outputs = taskflow.task @Task_o will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
 // DATAFLOW-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // DATAFLOW-NEXT:       %0 = neura.kernel inputs(%arg3, %arg4, %arg5 : memref<?xi32>, memref<?xi32>, i32) attributes {accelerator = "neura", dataflow_mode = "predicate"} {
 // DATAFLOW-NEXT:       ^bb0(%arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: i32):
@@ -140,7 +140,7 @@ module {
 // DATAFLOW-NEXT:         neura.ctrl_mov %18 -> %5 : !neura.data<i32, i1> !neura.data<i32, i1>
 // DATAFLOW-NEXT:         neura.yield
 // DATAFLOW-NEXT:       } : i32
-// DATAFLOW-NEXT:       taskflow.yield done_read(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
+// DATAFLOW-NEXT:       taskflow.yield done_reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
 // DATAFLOW-NEXT:     }
 // DATAFLOW-NEXT:     return %value_outputs : i32
 // DATAFLOW-NEXT:   }
@@ -150,7 +150,7 @@ module {
 // MAPPED: module {
 // MAPPED-NEXT:   func.func @_Z6kernelPiS_S_(%arg0: memref<?xi32>, %arg1: memref<?xi32>, %arg2: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // MAPPED-NEXT:     %c0_i32 = arith.constant 0 : i32
-// MAPPED-NEXT:     %done_read:2, %value_outputs = taskflow.task @Task_o will_read(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
+// MAPPED-NEXT:     %done_reads:2, %value_outputs = taskflow.task @Task_o will_reads(%arg0, %arg2 : memref<?xi32>, memref<?xi32>) value_inputs(%c0_i32 : i32) : (memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>, memref<?xi32>, i32) {
 // MAPPED-NEXT:     ^bb0(%arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // MAPPED-NEXT:       %0 = neura.kernel inputs(%arg3, %arg4, %arg5 : memref<?xi32>, memref<?xi32>, i32) attributes {accelerator = "neura", dataflow_mode = "predicate", mapping_info = {compiled_ii = 6 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 4 : i32, res_mii = 1 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
 // MAPPED-NEXT:       ^bb0(%arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: i32):
@@ -193,7 +193,7 @@ module {
 // MAPPED-NEXT:         neura.ctrl_mov %32 -> %3 {dfg_id = 37 : i32, mapping_locs = [{id = 201 : i32, index_per_ii = 1 : i32, invalid_iterations = 1 : i32, per_tile_register_id = 9 : i32, resource = "register", time_step = 7 : i32}, {id = 201 : i32, index_per_ii = 2 : i32, invalid_iterations = 1 : i32, per_tile_register_id = 9 : i32, resource = "register", time_step = 8 : i32}, {id = 201 : i32, index_per_ii = 3 : i32, invalid_iterations = 1 : i32, per_tile_register_id = 9 : i32, resource = "register", time_step = 9 : i32}]} : !neura.data<i32, i1> !neura.data<i32, i1>
 // MAPPED-NEXT:         neura.yield {dfg_id = 4 : i32}
 // MAPPED-NEXT:       } : i32
-// MAPPED-NEXT:       taskflow.yield done_read(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
+// MAPPED-NEXT:       taskflow.yield done_reads(%arg3, %arg4 : memref<?xi32>, memref<?xi32>) values(%0 : i32)
 // MAPPED-NEXT:     }
 // MAPPED-NEXT:     return %value_outputs : i32
 // MAPPED-NEXT:   }

--- a/test/multi-cgra/kernel_mapping/relu/relu.mlir
+++ b/test/multi-cgra/kernel_mapping/relu/relu.mlir
@@ -96,7 +96,7 @@ module attributes {} {
 // TASKFLOW: module {
 // TASKFLOW-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // TASKFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// TASKFLOW-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // TASKFLOW-NEXT:       affine.for %arg6 = 0 to 32 {
 // TASKFLOW-NEXT:         %0 = affine.load %arg2[%arg6] : memref<?xi32>
@@ -111,7 +111,7 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %2, %arg4[%arg6] : memref<?xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
 // TASKFLOW-NEXT:     return
 // TASKFLOW-NEXT:   }
@@ -120,7 +120,7 @@ module attributes {} {
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // HYPERBLOCK-NEXT:     %c0_i32 = arith.constant 0 : i32
-// HYPERBLOCK-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c32 = arith.constant 32 : index
@@ -141,7 +141,7 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         }
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
 // HYPERBLOCK-NEXT:     return
 // HYPERBLOCK-NEXT:   }
@@ -150,7 +150,7 @@ module attributes {} {
 // KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // KERNEL-NEXT:     %c0_i32 = arith.constant 0 : i32
-// KERNEL-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // KERNEL-NEXT:       %c0 = arith.constant 0 : index
 // KERNEL-NEXT:       %c32 = arith.constant 32 : index
@@ -175,7 +175,7 @@ module attributes {} {
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:         neura.yield
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
 // KERNEL-NEXT:     }
 // KERNEL-NEXT:     return
 // KERNEL-NEXT:   }
@@ -184,7 +184,7 @@ module attributes {} {
 // NEURA:      module {
 // NEURA-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // NEURA-NEXT:     %c0_i32 = arith.constant 0 : i32
-// NEURA-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// NEURA-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // NEURA-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // NEURA-NEXT:       %c0 = arith.constant 0 : index
 // NEURA-NEXT:       %c32 = arith.constant 32 : index
@@ -212,7 +212,7 @@ module attributes {} {
 // NEURA-NEXT:       ^bb3:  // 2 preds: ^bb1, ^bb2
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
+// NEURA-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
 // NEURA-NEXT:     }
 // NEURA-NEXT:     return
 // NEURA-NEXT:   }
@@ -221,7 +221,7 @@ module attributes {} {
 // DATAFLOW:      module {
 // DATAFLOW-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // DATAFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// DATAFLOW-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// DATAFLOW-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // DATAFLOW-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // DATAFLOW-NEXT:       %c0 = arith.constant 0 : index
 // DATAFLOW-NEXT:       %c32 = arith.constant 32 : index
@@ -243,7 +243,7 @@ module attributes {} {
 // DATAFLOW-NEXT:         neura.store_indexed %10 to [%4 : !neura.data<index, i1>]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // DATAFLOW-NEXT:         neura.yield {yield_type = "void"}
 // DATAFLOW-NEXT:       }
-// DATAFLOW-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
+// DATAFLOW-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
 // DATAFLOW-NEXT:     }
 // DATAFLOW-NEXT:     return
 // DATAFLOW-NEXT:   }
@@ -252,7 +252,7 @@ module attributes {} {
 // MAPPED:      module {
 // MAPPED-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // MAPPED-NEXT:     %c0_i32 = arith.constant 0 : i32
-// MAPPED-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) dependency_write_in(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// MAPPED-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // MAPPED-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // MAPPED-NEXT:       %c0 = arith.constant 0 : index
 // MAPPED-NEXT:       %c32 = arith.constant 32 : index
@@ -290,7 +290,7 @@ module attributes {} {
 // MAPPED-NEXT:         neura.store_indexed %25 to [%26 : !neura.data<index, i1>]  {dfg_id = 28 : i32, mapping_locs = [{id = 7 : i32, index_per_ii = 1 : i32, invalid_iterations = 3 : i32, resource = "tile", time_step = 7 : i32, x = 3 : i32, y = 1 : i32}], rhs_value = "%input2"} : !neura.data<i32, i1>
 // MAPPED-NEXT:         neura.yield {dfg_id = 1 : i32, yield_type = "void"}
 // MAPPED-NEXT:       }
-// MAPPED-NEXT:       taskflow.yield writes(%arg4 : memref<?xi32>)
+// MAPPED-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
 // MAPPED-NEXT:     }
 // MAPPED-NEXT:     return
 // MAPPED-NEXT:   }

--- a/test/multi-cgra/kernel_mapping/relu/relu.mlir
+++ b/test/multi-cgra/kernel_mapping/relu/relu.mlir
@@ -96,7 +96,7 @@ module attributes {} {
 // TASKFLOW: module {
 // TASKFLOW-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // TASKFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// TASKFLOW-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_writes(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // TASKFLOW-NEXT:       affine.for %arg6 = 0 to 32 {
 // TASKFLOW-NEXT:         %0 = affine.load %arg2[%arg6] : memref<?xi32>
@@ -111,7 +111,7 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %2, %arg4[%arg6] : memref<?xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg4 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
 // TASKFLOW-NEXT:     return
 // TASKFLOW-NEXT:   }
@@ -120,7 +120,7 @@ module attributes {} {
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // HYPERBLOCK-NEXT:     %c0_i32 = arith.constant 0 : i32
-// HYPERBLOCK-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_writes(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c32 = arith.constant 32 : index
@@ -141,7 +141,7 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         }
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg4 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
 // HYPERBLOCK-NEXT:     return
 // HYPERBLOCK-NEXT:   }
@@ -150,7 +150,7 @@ module attributes {} {
 // KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // KERNEL-NEXT:     %c0_i32 = arith.constant 0 : i32
-// KERNEL-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_writes(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // KERNEL-NEXT:       %c0 = arith.constant 0 : index
 // KERNEL-NEXT:       %c32 = arith.constant 32 : index
@@ -175,7 +175,7 @@ module attributes {} {
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:         neura.yield
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_writes(%arg4 : memref<?xi32>)
 // KERNEL-NEXT:     }
 // KERNEL-NEXT:     return
 // KERNEL-NEXT:   }
@@ -184,7 +184,7 @@ module attributes {} {
 // NEURA:      module {
 // NEURA-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // NEURA-NEXT:     %c0_i32 = arith.constant 0 : i32
-// NEURA-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// NEURA-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_writes(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // NEURA-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // NEURA-NEXT:       %c0 = arith.constant 0 : index
 // NEURA-NEXT:       %c32 = arith.constant 32 : index
@@ -212,7 +212,7 @@ module attributes {} {
 // NEURA-NEXT:       ^bb3:  // 2 preds: ^bb1, ^bb2
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
+// NEURA-NEXT:       taskflow.yield done_writes(%arg4 : memref<?xi32>)
 // NEURA-NEXT:     }
 // NEURA-NEXT:     return
 // NEURA-NEXT:   }
@@ -221,7 +221,7 @@ module attributes {} {
 // DATAFLOW:      module {
 // DATAFLOW-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // DATAFLOW-NEXT:     %c0_i32 = arith.constant 0 : i32
-// DATAFLOW-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// DATAFLOW-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_writes(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // DATAFLOW-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // DATAFLOW-NEXT:       %c0 = arith.constant 0 : index
 // DATAFLOW-NEXT:       %c32 = arith.constant 32 : index
@@ -243,7 +243,7 @@ module attributes {} {
 // DATAFLOW-NEXT:         neura.store_indexed %10 to [%4 : !neura.data<index, i1>]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // DATAFLOW-NEXT:         neura.yield {yield_type = "void"}
 // DATAFLOW-NEXT:       }
-// DATAFLOW-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
+// DATAFLOW-NEXT:       taskflow.yield done_writes(%arg4 : memref<?xi32>)
 // DATAFLOW-NEXT:     }
 // DATAFLOW-NEXT:     return
 // DATAFLOW-NEXT:   }
@@ -252,7 +252,7 @@ module attributes {} {
 // MAPPED:      module {
 // MAPPED-NEXT:   func.func @_Z6kernelPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // MAPPED-NEXT:     %c0_i32 = arith.constant 0 : i32
-// MAPPED-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_write(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
+// MAPPED-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0, %arg1 : memref<?xi32>, memref<?xi32>) will_writes(%arg1 : memref<?xi32>) value_inputs(%c0_i32 : i32) [original_read_memrefs(%arg0, %arg1 : memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg1 : memref<?xi32>)] {dlp_replicable = true} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, i32) -> (memref<?xi32>) {
 // MAPPED-NEXT:     ^bb0(%arg2: memref<?xi32>, %arg3: memref<?xi32>, %arg4: memref<?xi32>, %arg5: i32):
 // MAPPED-NEXT:       %c0 = arith.constant 0 : index
 // MAPPED-NEXT:       %c32 = arith.constant 32 : index
@@ -290,7 +290,7 @@ module attributes {} {
 // MAPPED-NEXT:         neura.store_indexed %25 to [%26 : !neura.data<index, i1>]  {dfg_id = 28 : i32, mapping_locs = [{id = 7 : i32, index_per_ii = 1 : i32, invalid_iterations = 3 : i32, resource = "tile", time_step = 7 : i32, x = 3 : i32, y = 1 : i32}], rhs_value = "%input2"} : !neura.data<i32, i1>
 // MAPPED-NEXT:         neura.yield {dfg_id = 1 : i32, yield_type = "void"}
 // MAPPED-NEXT:       }
-// MAPPED-NEXT:       taskflow.yield done_write(%arg4 : memref<?xi32>)
+// MAPPED-NEXT:       taskflow.yield done_writes(%arg4 : memref<?xi32>)
 // MAPPED-NEXT:     }
 // MAPPED-NEXT:     return
 // MAPPED-NEXT:   }

--- a/test/multi-cgra/taskflow/allocation-with-resource-binding/allocation-with-resource-binding.mlir
+++ b/test/multi-cgra/taskflow/allocation-with-resource-binding/allocation-with-resource-binding.mlir
@@ -20,8 +20,8 @@ module {
 
     // Task_0: writes %A.  Allocated to 2 CGRAs with shape 1x2.
     %dr0, %dw0 = taskflow.task @Task_0
-        will_read(%A : memref<64xf32>)
-        will_write(%A : memref<64xf32>)
+        will_reads(%A : memref<64xf32>)
+        will_writes(%A : memref<64xf32>)
         value_inputs(%val : f32)
         [original_read_memrefs(%A : memref<64xf32>),
          original_write_memrefs(%A : memref<64xf32>)]
@@ -29,13 +29,13 @@ module {
         : (memref<64xf32>, memref<64xf32>, f32)
        -> (memref<64xf32>, memref<64xf32>) {
     ^bb0(%a0: memref<64xf32>, %a1: memref<64xf32>, %v: f32):
-      taskflow.yield done_read(%a0 : memref<64xf32>) done_write(%a1 : memref<64xf32>)
+      taskflow.yield done_reads(%a0 : memref<64xf32>) done_writes(%a1 : memref<64xf32>)
     }
 
     // Task_1: reads %A (via Task_0 output), writes %B.  Single CGRA.
     %dr1, %dw1 = taskflow.task @Task_1
-        will_read(%dw0 : memref<64xf32>)
-        will_write(%B : memref<64xf32>)
+        will_reads(%dw0 : memref<64xf32>)
+        will_writes(%B : memref<64xf32>)
         value_inputs(%dr0 : memref<64xf32>)
         [original_read_memrefs(%A : memref<64xf32>),
          original_write_memrefs(%B : memref<64xf32>)]
@@ -43,13 +43,13 @@ module {
         : (memref<64xf32>, memref<64xf32>, memref<64xf32>)
        -> (memref<64xf32>, memref<64xf32>) {
     ^bb0(%a0: memref<64xf32>, %b0: memref<64xf32>, %a1: memref<64xf32>):
-      taskflow.yield done_read(%a0 : memref<64xf32>) done_write(%b0 : memref<64xf32>)
+      taskflow.yield done_reads(%a0 : memref<64xf32>) done_writes(%b0 : memref<64xf32>)
     }
 
     // Task_2: reads %B (via Task_1 output), writes %C.  Single CGRA.
     %dr2, %dw2 = taskflow.task @Task_2
-        will_read(%dw1 : memref<64xf32>)
-        will_write(%C : memref<64xf32>)
+        will_reads(%dw1 : memref<64xf32>)
+        will_writes(%C : memref<64xf32>)
         value_inputs(%dr1 : memref<64xf32>)
         [original_read_memrefs(%B : memref<64xf32>),
          original_write_memrefs(%C : memref<64xf32>)]
@@ -57,7 +57,7 @@ module {
         : (memref<64xf32>, memref<64xf32>, memref<64xf32>)
        -> (memref<64xf32>, memref<64xf32>) {
     ^bb0(%b0: memref<64xf32>, %c0: memref<64xf32>, %b1: memref<64xf32>):
-      taskflow.yield done_read(%b0 : memref<64xf32>) done_write(%c0 : memref<64xf32>)
+      taskflow.yield done_reads(%b0 : memref<64xf32>) done_writes(%c0 : memref<64xf32>)
     }
 
     return
@@ -66,17 +66,17 @@ module {
 
 // CHECK: module {
 // CHECK-NEXT:   func.func @resource_binding_chain(%arg0: memref<64xf32>, %arg1: memref<64xf32>, %arg2: memref<64xf32>, %arg3: f32) {
-// CHECK-NEXT:     %done_read, %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<64xf32>) will_write(%arg0 : memref<64xf32>) value_inputs(%arg3 : f32) [original_read_memrefs(%arg0 : memref<64xf32>), original_write_memrefs(%arg0 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}, {col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, f32) -> (memref<64xf32>, memref<64xf32>) {
+// CHECK-NEXT:     %done_reads, %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<64xf32>) will_writes(%arg0 : memref<64xf32>) value_inputs(%arg3 : f32) [original_read_memrefs(%arg0 : memref<64xf32>), original_write_memrefs(%arg0 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}, {col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, f32) -> (memref<64xf32>, memref<64xf32>) {
 // CHECK-NEXT:     ^bb0(%arg4: memref<64xf32>, %arg5: memref<64xf32>, %arg6: f32):
-// CHECK-NEXT:       taskflow.yield done_read(%arg4 : memref<64xf32>) done_write(%arg5 : memref<64xf32>)
+// CHECK-NEXT:       taskflow.yield done_reads(%arg4 : memref<64xf32>) done_writes(%arg5 : memref<64xf32>)
 // CHECK-NEXT:     }
-// CHECK-NEXT:     %done_read_0, %done_write_1 = taskflow.task @Task_1 will_read(%done_write : memref<64xf32>) will_write(%arg1 : memref<64xf32>) value_inputs(%done_read : memref<64xf32>) [original_read_memrefs(%arg0 : memref<64xf32>), original_write_memrefs(%arg1 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, memref<64xf32>) -> (memref<64xf32>, memref<64xf32>) {
+// CHECK-NEXT:     %done_reads_0, %done_writes_1 = taskflow.task @Task_1 will_reads(%done_writes : memref<64xf32>) will_writes(%arg1 : memref<64xf32>) value_inputs(%done_reads : memref<64xf32>) [original_read_memrefs(%arg0 : memref<64xf32>), original_write_memrefs(%arg1 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, memref<64xf32>) -> (memref<64xf32>, memref<64xf32>) {
 // CHECK-NEXT:     ^bb0(%arg4: memref<64xf32>, %arg5: memref<64xf32>, %arg6: memref<64xf32>):
-// CHECK-NEXT:       taskflow.yield done_read(%arg4 : memref<64xf32>) done_write(%arg5 : memref<64xf32>)
+// CHECK-NEXT:       taskflow.yield done_reads(%arg4 : memref<64xf32>) done_writes(%arg5 : memref<64xf32>)
 // CHECK-NEXT:     }
-// CHECK-NEXT:     %done_read_2, %done_write_3 = taskflow.task @Task_2 will_read(%done_write_1 : memref<64xf32>) will_write(%arg2 : memref<64xf32>) value_inputs(%done_read_0 : memref<64xf32>) [original_read_memrefs(%arg1 : memref<64xf32>), original_write_memrefs(%arg2 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, memref<64xf32>) -> (memref<64xf32>, memref<64xf32>) {
+// CHECK-NEXT:     %done_reads_2, %done_writes_3 = taskflow.task @Task_2 will_reads(%done_writes_1 : memref<64xf32>) will_writes(%arg2 : memref<64xf32>) value_inputs(%done_reads_0 : memref<64xf32>) [original_read_memrefs(%arg1 : memref<64xf32>), original_write_memrefs(%arg2 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, memref<64xf32>) -> (memref<64xf32>, memref<64xf32>) {
 // CHECK-NEXT:     ^bb0(%arg4: memref<64xf32>, %arg5: memref<64xf32>, %arg6: memref<64xf32>):
-// CHECK-NEXT:       taskflow.yield done_read(%arg4 : memref<64xf32>) done_write(%arg5 : memref<64xf32>)
+// CHECK-NEXT:       taskflow.yield done_reads(%arg4 : memref<64xf32>) done_writes(%arg5 : memref<64xf32>)
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/test/multi-cgra/taskflow/allocation-with-resource-binding/allocation-with-resource-binding.mlir
+++ b/test/multi-cgra/taskflow/allocation-with-resource-binding/allocation-with-resource-binding.mlir
@@ -20,8 +20,8 @@ module {
 
     // Task_0: writes %A.  Allocated to 2 CGRAs with shape 1x2.
     %dr0, %dw0 = taskflow.task @Task_0
-        dependency_read_in(%A : memref<64xf32>)
-        dependency_write_in(%A : memref<64xf32>)
+        will_read(%A : memref<64xf32>)
+        will_write(%A : memref<64xf32>)
         value_inputs(%val : f32)
         [original_read_memrefs(%A : memref<64xf32>),
          original_write_memrefs(%A : memref<64xf32>)]
@@ -29,13 +29,13 @@ module {
         : (memref<64xf32>, memref<64xf32>, f32)
        -> (memref<64xf32>, memref<64xf32>) {
     ^bb0(%a0: memref<64xf32>, %a1: memref<64xf32>, %v: f32):
-      taskflow.yield reads(%a0 : memref<64xf32>) writes(%a1 : memref<64xf32>)
+      taskflow.yield done_read(%a0 : memref<64xf32>) done_write(%a1 : memref<64xf32>)
     }
 
     // Task_1: reads %A (via Task_0 output), writes %B.  Single CGRA.
     %dr1, %dw1 = taskflow.task @Task_1
-        dependency_read_in(%dw0 : memref<64xf32>)
-        dependency_write_in(%B : memref<64xf32>)
+        will_read(%dw0 : memref<64xf32>)
+        will_write(%B : memref<64xf32>)
         value_inputs(%dr0 : memref<64xf32>)
         [original_read_memrefs(%A : memref<64xf32>),
          original_write_memrefs(%B : memref<64xf32>)]
@@ -43,13 +43,13 @@ module {
         : (memref<64xf32>, memref<64xf32>, memref<64xf32>)
        -> (memref<64xf32>, memref<64xf32>) {
     ^bb0(%a0: memref<64xf32>, %b0: memref<64xf32>, %a1: memref<64xf32>):
-      taskflow.yield reads(%a0 : memref<64xf32>) writes(%b0 : memref<64xf32>)
+      taskflow.yield done_read(%a0 : memref<64xf32>) done_write(%b0 : memref<64xf32>)
     }
 
     // Task_2: reads %B (via Task_1 output), writes %C.  Single CGRA.
     %dr2, %dw2 = taskflow.task @Task_2
-        dependency_read_in(%dw1 : memref<64xf32>)
-        dependency_write_in(%C : memref<64xf32>)
+        will_read(%dw1 : memref<64xf32>)
+        will_write(%C : memref<64xf32>)
         value_inputs(%dr1 : memref<64xf32>)
         [original_read_memrefs(%B : memref<64xf32>),
          original_write_memrefs(%C : memref<64xf32>)]
@@ -57,7 +57,7 @@ module {
         : (memref<64xf32>, memref<64xf32>, memref<64xf32>)
        -> (memref<64xf32>, memref<64xf32>) {
     ^bb0(%b0: memref<64xf32>, %c0: memref<64xf32>, %b1: memref<64xf32>):
-      taskflow.yield reads(%b0 : memref<64xf32>) writes(%c0 : memref<64xf32>)
+      taskflow.yield done_read(%b0 : memref<64xf32>) done_write(%c0 : memref<64xf32>)
     }
 
     return
@@ -66,17 +66,17 @@ module {
 
 // CHECK: module {
 // CHECK-NEXT:   func.func @resource_binding_chain(%arg0: memref<64xf32>, %arg1: memref<64xf32>, %arg2: memref<64xf32>, %arg3: f32) {
-// CHECK-NEXT:     %dependency_read_out, %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<64xf32>) dependency_write_in(%arg0 : memref<64xf32>) value_inputs(%arg3 : f32) [original_read_memrefs(%arg0 : memref<64xf32>), original_write_memrefs(%arg0 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}, {col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, f32) -> (memref<64xf32>, memref<64xf32>) {
+// CHECK-NEXT:     %done_read, %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<64xf32>) will_write(%arg0 : memref<64xf32>) value_inputs(%arg3 : f32) [original_read_memrefs(%arg0 : memref<64xf32>), original_write_memrefs(%arg0 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}, {col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, f32) -> (memref<64xf32>, memref<64xf32>) {
 // CHECK-NEXT:     ^bb0(%arg4: memref<64xf32>, %arg5: memref<64xf32>, %arg6: f32):
-// CHECK-NEXT:       taskflow.yield reads(%arg4 : memref<64xf32>) writes(%arg5 : memref<64xf32>)
+// CHECK-NEXT:       taskflow.yield done_read(%arg4 : memref<64xf32>) done_write(%arg5 : memref<64xf32>)
 // CHECK-NEXT:     }
-// CHECK-NEXT:     %dependency_read_out_0, %dependency_write_out_1 = taskflow.task @Task_1 dependency_read_in(%dependency_write_out : memref<64xf32>) dependency_write_in(%arg1 : memref<64xf32>) value_inputs(%dependency_read_out : memref<64xf32>) [original_read_memrefs(%arg0 : memref<64xf32>), original_write_memrefs(%arg1 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, memref<64xf32>) -> (memref<64xf32>, memref<64xf32>) {
+// CHECK-NEXT:     %done_read_0, %done_write_1 = taskflow.task @Task_1 will_read(%done_write : memref<64xf32>) will_write(%arg1 : memref<64xf32>) value_inputs(%done_read : memref<64xf32>) [original_read_memrefs(%arg0 : memref<64xf32>), original_write_memrefs(%arg1 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, memref<64xf32>) -> (memref<64xf32>, memref<64xf32>) {
 // CHECK-NEXT:     ^bb0(%arg4: memref<64xf32>, %arg5: memref<64xf32>, %arg6: memref<64xf32>):
-// CHECK-NEXT:       taskflow.yield reads(%arg4 : memref<64xf32>) writes(%arg5 : memref<64xf32>)
+// CHECK-NEXT:       taskflow.yield done_read(%arg4 : memref<64xf32>) done_write(%arg5 : memref<64xf32>)
 // CHECK-NEXT:     }
-// CHECK-NEXT:     %dependency_read_out_2, %dependency_write_out_3 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out_1 : memref<64xf32>) dependency_write_in(%arg2 : memref<64xf32>) value_inputs(%dependency_read_out_0 : memref<64xf32>) [original_read_memrefs(%arg1 : memref<64xf32>), original_write_memrefs(%arg2 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, memref<64xf32>) -> (memref<64xf32>, memref<64xf32>) {
+// CHECK-NEXT:     %done_read_2, %done_write_3 = taskflow.task @Task_2 will_read(%done_write_1 : memref<64xf32>) will_write(%arg2 : memref<64xf32>) value_inputs(%done_read_0 : memref<64xf32>) [original_read_memrefs(%arg1 : memref<64xf32>), original_write_memrefs(%arg2 : memref<64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<64xf32>, memref<64xf32>, memref<64xf32>) -> (memref<64xf32>, memref<64xf32>) {
 // CHECK-NEXT:     ^bb0(%arg4: memref<64xf32>, %arg5: memref<64xf32>, %arg6: memref<64xf32>):
-// CHECK-NEXT:       taskflow.yield reads(%arg4 : memref<64xf32>) writes(%arg5 : memref<64xf32>)
+// CHECK-NEXT:       taskflow.yield done_read(%arg4 : memref<64xf32>) done_write(%arg5 : memref<64xf32>)
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/test/multi-cgra/taskflow/irregular-loop/irregular-loop.mlir
+++ b/test/multi-cgra/taskflow/irregular-loop/irregular-loop.mlir
@@ -220,7 +220,7 @@ module attributes {} {
 // TASKFLOW-NEXT:       }
 // TASKFLOW-NEXT:       taskflow.yield values(%1 : i32)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// TASKFLOW-NEXT:     %done_writes = taskflow.task @Task_1 will_writes(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // TASKFLOW-NEXT:       affine.for %arg2 = 0 to 4 {
 // TASKFLOW-NEXT:         %1 = arith.index_cast %arg2 : index to i32
@@ -231,9 +231,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %4, %arg0[%arg2, %arg3] : memref<4x8xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg0 : memref<4x8xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// TASKFLOW-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes : memref<4x8xi32>) will_writes(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // TASKFLOW-NEXT:       affine.for %arg5 = 0 to 4 {
 // TASKFLOW-NEXT:         %1 = arith.index_cast %arg5 : index to i32
@@ -248,9 +248,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg1 : memref<i32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
+// TASKFLOW-NEXT:     %0 = affine.load %done_writes_1[] : memref<i32>
 // TASKFLOW-NEXT:     return %0 : i32
 // TASKFLOW-NEXT:   }
 // TASKFLOW-NEXT: }
@@ -278,7 +278,7 @@ module attributes {} {
 // KERNEL-NEXT:       } : i32
 // KERNEL-NEXT:       taskflow.yield values(%1 : i32)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// KERNEL-NEXT:     %done_writes = taskflow.task @Task_1 will_writes(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // KERNEL-NEXT:       affine.for %arg2 = 0 to 4 {
 // KERNEL-NEXT:         %1 = arith.index_cast %arg2 : index to i32
@@ -296,9 +296,9 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
+// KERNEL-NEXT:       taskflow.yield done_writes(%arg0 : memref<4x8xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// KERNEL-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes : memref<4x8xi32>) will_writes(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // KERNEL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // KERNEL-NEXT:       affine.for %arg5 = 0 to 4 {
 // KERNEL-NEXT:         neura.kernel inputs(%arg0, %arg5, %arg3, %arg1, %arg4 : memref<4x8xi32>, index, i32, memref<i32>, i32) {
@@ -325,9 +325,9 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
+// KERNEL-NEXT:       taskflow.yield done_writes(%arg1 : memref<i32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
+// KERNEL-NEXT:     %0 = affine.load %done_writes_1[] : memref<i32>
 // KERNEL-NEXT:     return %0 : i32
 // KERNEL-NEXT:   }
 // KERNEL-NEXT: }
@@ -353,7 +353,7 @@ module attributes {} {
 // HYPERBLOCK-NEXT:       }) : (index, i32) -> i32
 // HYPERBLOCK-NEXT:       taskflow.yield values(%2 : i32)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// HYPERBLOCK-NEXT:     %done_writes = taskflow.task @Task_1 will_writes(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -373,9 +373,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         }
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg0 : memref<4x8xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// HYPERBLOCK-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes : memref<4x8xi32>) will_writes(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -407,9 +407,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         }
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg1 : memref<i32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
+// HYPERBLOCK-NEXT:     %0 = affine.load %done_writes_1[] : memref<i32>
 // HYPERBLOCK-NEXT:     return %0 : i32
 // HYPERBLOCK-NEXT:   }
 // HYPERBLOCK-NEXT: }
@@ -436,7 +436,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       }) : (index, i32) -> i32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield values(%2 : i32)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 2 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %done_writes = taskflow.task @Task_1 will_writes(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 2 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c4 = arith.constant 4 : index
@@ -456,9 +456,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield done_writes(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes : memref<4x8xi32>) will_writes(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c4 = arith.constant 4 : index
@@ -490,9 +490,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield done_writes(%arg1 : memref<i32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %0 = affine.load %done_writes_1[] : memref<i32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     return %0 : i32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:   }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT: }
@@ -518,7 +518,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       }) : (index, i32) -> i32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield values(%2 : i32)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %done_writes = taskflow.task @Task_1 will_writes(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c4 = arith.constant 4 : index
@@ -538,9 +538,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield done_writes(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes : memref<4x8xi32>) will_writes(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c4 = arith.constant 4 : index
@@ -572,9 +572,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield done_writes(%arg1 : memref<i32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %0 = affine.load %done_writes_1[] : memref<i32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:   }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT: }
@@ -600,7 +600,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       }) : (index, i32) -> i32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield values(%2 : i32)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %done_writes = taskflow.task @Task_1 will_writes(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c4 = arith.constant 4 : index
@@ -620,9 +620,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield done_writes(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes : memref<4x8xi32>) will_writes(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c4 = arith.constant 4 : index
@@ -654,9 +654,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield done_writes(%arg1 : memref<i32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %0 = affine.load %done_writes_1[] : memref<i32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:   }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT: }
@@ -682,7 +682,7 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:       }) : (index, i32) -> i32
 // MAP-SPATIAL-NEXT:       taskflow.yield values(%2 : i32)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 2 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// MAP-SPATIAL-NEXT:     %done_writes = taskflow.task @Task_1 will_writes(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 2 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -702,9 +702,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         }
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_writes(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// MAP-SPATIAL-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes : memref<4x8xi32>) will_writes(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -736,9 +736,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         }
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_writes(%arg1 : memref<i32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
+// MAP-SPATIAL-NEXT:     %0 = affine.load %done_writes_1[] : memref<i32>
 // MAP-SPATIAL-NEXT:     return %0 : i32
 // MAP-SPATIAL-NEXT:   }
 // MAP-SPATIAL-NEXT: }
@@ -751,7 +751,7 @@ module attributes {} {
 // RESOPT-NEXT:     %c0_i32 = arith.constant 0 : i32
 // RESOPT-NEXT:     %alloca = memref.alloca() : memref<i32>
 // RESOPT-NEXT:     %alloca_0 = memref.alloca() : memref<4x8xi32>
-// RESOPT-NEXT:     %done_write, %value_outputs = taskflow.task @Task_0_Task_1_utilfused will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c0_i32, %c8_i32 : i32, i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 3 : i32, profile_info = {duration = 5 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, i32, i32) -> (memref<4x8xi32>, i32) {
+// RESOPT-NEXT:     %done_writes, %value_outputs = taskflow.task @Task_0_Task_1_utilfused will_writes(%alloca_0 : memref<4x8xi32>) value_inputs(%c0_i32, %c8_i32 : i32, i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 3 : i32, profile_info = {duration = 5 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, i32, i32) -> (memref<4x8xi32>, i32) {
 // RESOPT-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32, %arg2: i32):
 // RESOPT-NEXT:       %c0 = arith.constant 0 : index
 // RESOPT-NEXT:       %c5 = arith.constant 5 : index
@@ -785,9 +785,9 @@ module attributes {} {
 // RESOPT-NEXT:       %c1_3 = arith.constant 1 : index
 // RESOPT-NEXT:       %3 = taskflow.counter from %c0_2 to %c4 step %c1_3 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
 // RESOPT-NEXT:       %4 = taskflow.counter parent(%3 : index) from %c0_2 to %c8 step %c1_3 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>) values(%2 : i32)
+// RESOPT-NEXT:       taskflow.yield done_writes(%arg0 : memref<4x8xi32>) values(%2 : i32)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 7 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// RESOPT-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes : memref<4x8xi32>) will_writes(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 7 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // RESOPT-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
 // RESOPT-NEXT:       %c0 = arith.constant 0 : index
@@ -812,9 +812,9 @@ module attributes {} {
 // RESOPT-NEXT:         neura.store_indexed %13 to [ : ]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
+// RESOPT-NEXT:       taskflow.yield done_writes(%arg1 : memref<i32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %0 = memref.load %done_write_1[] : memref<i32>
+// RESOPT-NEXT:     %0 = memref.load %done_writes_1[] : memref<i32>
 // RESOPT-NEXT:     return %0 : i32
 // RESOPT-NEXT:   }
 // RESOPT-NEXT: }

--- a/test/multi-cgra/taskflow/irregular-loop/irregular-loop.mlir
+++ b/test/multi-cgra/taskflow/irregular-loop/irregular-loop.mlir
@@ -220,7 +220,7 @@ module attributes {} {
 // TASKFLOW-NEXT:       }
 // TASKFLOW-NEXT:       taskflow.yield values(%1 : i32)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_write_in(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// TASKFLOW-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // TASKFLOW-NEXT:       affine.for %arg2 = 0 to 4 {
 // TASKFLOW-NEXT:         %1 = arith.index_cast %arg2 : index to i32
@@ -231,9 +231,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %4, %arg0[%arg2, %arg3] : memref<4x8xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// TASKFLOW-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // TASKFLOW-NEXT:       affine.for %arg5 = 0 to 4 {
 // TASKFLOW-NEXT:         %1 = arith.index_cast %arg5 : index to i32
@@ -248,9 +248,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
+// TASKFLOW-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
 // TASKFLOW-NEXT:     return %0 : i32
 // TASKFLOW-NEXT:   }
 // TASKFLOW-NEXT: }
@@ -278,7 +278,7 @@ module attributes {} {
 // KERNEL-NEXT:       } : i32
 // KERNEL-NEXT:       taskflow.yield values(%1 : i32)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_write_in(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// KERNEL-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // KERNEL-NEXT:       affine.for %arg2 = 0 to 4 {
 // KERNEL-NEXT:         %1 = arith.index_cast %arg2 : index to i32
@@ -296,9 +296,9 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
+// KERNEL-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// KERNEL-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // KERNEL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // KERNEL-NEXT:       affine.for %arg5 = 0 to 4 {
 // KERNEL-NEXT:         neura.kernel inputs(%arg0, %arg5, %arg3, %arg1, %arg4 : memref<4x8xi32>, index, i32, memref<i32>, i32) {
@@ -325,9 +325,9 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
+// KERNEL-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
+// KERNEL-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
 // KERNEL-NEXT:     return %0 : i32
 // KERNEL-NEXT:   }
 // KERNEL-NEXT: }
@@ -353,7 +353,7 @@ module attributes {} {
 // HYPERBLOCK-NEXT:       }) : (index, i32) -> i32
 // HYPERBLOCK-NEXT:       taskflow.yield values(%2 : i32)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_write_in(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// HYPERBLOCK-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -373,9 +373,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         }
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// HYPERBLOCK-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -407,9 +407,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         }
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
+// HYPERBLOCK-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
 // HYPERBLOCK-NEXT:     return %0 : i32
 // HYPERBLOCK-NEXT:   }
 // HYPERBLOCK-NEXT: }
@@ -436,7 +436,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       }) : (index, i32) -> i32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield values(%2 : i32)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_write_in(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 2 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 2 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c4 = arith.constant 4 : index
@@ -456,9 +456,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       %c4 = arith.constant 4 : index
@@ -490,9 +490,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:     return %0 : i32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:   }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT: }
@@ -518,7 +518,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       }) : (index, i32) -> i32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield values(%2 : i32)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_write_in(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c4 = arith.constant 4 : index
@@ -538,9 +538,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       %c4 = arith.constant 4 : index
@@ -572,9 +572,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:     return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:   }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT: }
@@ -600,7 +600,7 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       }) : (index, i32) -> i32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield values(%2 : i32)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_write_in(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c4 = arith.constant 4 : index
@@ -620,9 +620,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       %c4 = arith.constant 4 : index
@@ -654,9 +654,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:     return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:   }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT: }
@@ -682,7 +682,7 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:       }) : (index, i32) -> i32
 // MAP-SPATIAL-NEXT:       taskflow.yield values(%2 : i32)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_write_in(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 2 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
+// MAP-SPATIAL-NEXT:     %done_write = taskflow.task @Task_1 will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c8_i32 : i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 2 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, i32) -> (memref<4x8xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -702,9 +702,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         }
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// MAP-SPATIAL-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -736,9 +736,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         }
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %0 = affine.load %dependency_write_out_1[] : memref<i32>
+// MAP-SPATIAL-NEXT:     %0 = affine.load %done_write_1[] : memref<i32>
 // MAP-SPATIAL-NEXT:     return %0 : i32
 // MAP-SPATIAL-NEXT:   }
 // MAP-SPATIAL-NEXT: }
@@ -751,7 +751,7 @@ module attributes {} {
 // RESOPT-NEXT:     %c0_i32 = arith.constant 0 : i32
 // RESOPT-NEXT:     %alloca = memref.alloca() : memref<i32>
 // RESOPT-NEXT:     %alloca_0 = memref.alloca() : memref<4x8xi32>
-// RESOPT-NEXT:     %dependency_write_out, %value_outputs = taskflow.task @Task_0_Task_1_utilfused dependency_write_in(%alloca_0 : memref<4x8xi32>) value_inputs(%c0_i32, %c8_i32 : i32, i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 3 : i32, profile_info = {duration = 5 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, i32, i32) -> (memref<4x8xi32>, i32) {
+// RESOPT-NEXT:     %done_write, %value_outputs = taskflow.task @Task_0_Task_1_utilfused will_write(%alloca_0 : memref<4x8xi32>) value_inputs(%c0_i32, %c8_i32 : i32, i32) [original_write_memrefs(%alloca_0 : memref<4x8xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 3 : i32, profile_info = {duration = 5 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, i32, i32) -> (memref<4x8xi32>, i32) {
 // RESOPT-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: i32, %arg2: i32):
 // RESOPT-NEXT:       %c0 = arith.constant 0 : index
 // RESOPT-NEXT:       %c5 = arith.constant 5 : index
@@ -785,9 +785,9 @@ module attributes {} {
 // RESOPT-NEXT:       %c1_3 = arith.constant 1 : index
 // RESOPT-NEXT:       %3 = taskflow.counter from %c0_2 to %c4 step %c1_3 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
 // RESOPT-NEXT:       %4 = taskflow.counter parent(%3 : index) from %c0_2 to %c8 step %c1_3 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       taskflow.yield writes(%arg0 : memref<4x8xi32>) values(%2 : i32)
+// RESOPT-NEXT:       taskflow.yield done_write(%arg0 : memref<4x8xi32>) values(%2 : i32)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out : memref<4x8xi32>) dependency_write_in(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 7 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
+// RESOPT-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write : memref<4x8xi32>) will_write(%alloca : memref<i32>) value_inputs(%c8_i32, %value_outputs, %c2_i32 : i32, i32, i32) [original_read_memrefs(%alloca_0 : memref<4x8xi32>), original_write_memrefs(%alloca : memref<i32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 7 : i32}, trip_count = 32 : i32} : (memref<4x8xi32>, memref<i32>, i32, i32, i32) -> (memref<i32>) {
 // RESOPT-NEXT:     ^bb0(%arg0: memref<4x8xi32>, %arg1: memref<i32>, %arg2: i32, %arg3: i32, %arg4: i32):
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
 // RESOPT-NEXT:       %c0 = arith.constant 0 : index
@@ -812,9 +812,9 @@ module attributes {} {
 // RESOPT-NEXT:         neura.store_indexed %13 to [ : ]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       taskflow.yield writes(%arg1 : memref<i32>)
+// RESOPT-NEXT:       taskflow.yield done_write(%arg1 : memref<i32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %0 = memref.load %dependency_write_out_1[] : memref<i32>
+// RESOPT-NEXT:     %0 = memref.load %done_write_1[] : memref<i32>
 // RESOPT-NEXT:     return %0 : i32
 // RESOPT-NEXT:   }
 // RESOPT-NEXT: }

--- a/test/multi-cgra/taskflow/multi-nested/multi-nested.mlir
+++ b/test/multi-cgra/taskflow/multi-nested/multi-nested.mlir
@@ -238,7 +238,7 @@ module attributes {} {
 
 // TASKFLOW:      module {
 // TASKFLOW-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// TASKFLOW-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg12 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg13 = 0 to 8 {
@@ -248,9 +248,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg13 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg14 = 0 to 8 {
@@ -262,9 +262,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg14 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg15 = 0 to 8 {
@@ -278,9 +278,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg13 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg13 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg12 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg13 = 0 to 7 {
@@ -288,9 +288,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %1, %arg11[%arg13] : memref<?xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg13 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg14 = 0 to 9 {
@@ -300,16 +300,16 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %3, %arg12[%arg14] : memref<?xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
+// TASKFLOW-NEXT:     %0 = affine.load %done_write_1[0] : memref<?xi32>
 // TASKFLOW-NEXT:     return %0 : i32
 // TASKFLOW-NEXT:   }
 // TASKFLOW-NEXT: }
 
 // STREAM:      module {
 // STREAM-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// STREAM-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// STREAM-NEXT:     %done_write = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg13 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg14 = 0 to 8 {
@@ -321,9 +321,9 @@ module attributes {} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_read_out:3, %dependency_write_out_0 = taskflow.task @Task_0_Task_2_fused dependency_read_in(%arg0, %dependency_write_out, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// STREAM-NEXT:     %done_read:3, %done_write_0 = taskflow.task @Task_0_Task_2_fused will_read(%arg0, %done_write, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg14 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg15 = 0 to 8 {
@@ -337,9 +337,9 @@ module attributes {} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg10, %arg11, %arg12 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) writes(%arg12 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield done_read(%arg10, %arg11, %arg12 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) done_write(%arg12 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_write_out_1 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// STREAM-NEXT:     %done_write_1 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg12 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg13 = 0 to 7 {
@@ -347,9 +347,9 @@ module attributes {} {
 // STREAM-NEXT:           affine.store %1, %arg11[%arg13] : memref<?xi32>
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_write_out_2 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_1 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// STREAM-NEXT:     %done_write_2 = taskflow.task @Task_4 will_read(%arg4, %done_write_1 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg13 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg14 = 0 to 9 {
@@ -359,16 +359,16 @@ module attributes {} {
 // STREAM-NEXT:           affine.store %3, %arg12[%arg14] : memref<?xi32>
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %0 = affine.load %dependency_write_out_0[0] : memref<?xi32>
+// STREAM-NEXT:     %0 = affine.load %done_write_0[0] : memref<?xi32>
 // STREAM-NEXT:     return %0 : i32
 // STREAM-NEXT:   }
 // STREAM-NEXT: }
 
 // KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// KERNEL-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg12 = 0 to 4 {
 // KERNEL-NEXT:         affine.for %arg13 = 0 to 8 {
@@ -385,9 +385,9 @@ module attributes {} {
 // KERNEL-NEXT:           }
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg13 = 0 to 4 {
 // KERNEL-NEXT:         affine.for %arg14 = 0 to 8 {
@@ -406,9 +406,9 @@ module attributes {} {
 // KERNEL-NEXT:           }
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg14 = 0 to 4 {
 // KERNEL-NEXT:         affine.for %arg15 = 0 to 8 {
@@ -429,9 +429,9 @@ module attributes {} {
 // KERNEL-NEXT:           }
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield writes(%arg13 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_write(%arg13 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg12 = 0 to 4 {
 // KERNEL-NEXT:         neura.kernel inputs(%arg10, %arg12, %arg11 : memref<?x7xi32>, index, memref<?xi32>) {
@@ -446,9 +446,9 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg13 = 0 to 4 {
 // KERNEL-NEXT:         neura.kernel inputs(%arg10, %arg13, %arg11, %arg12 : memref<?x9xi32>, index, memref<?xi32>, memref<?xi32>) {
@@ -465,16 +465,16 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
+// KERNEL-NEXT:     %0 = affine.load %done_write_1[0] : memref<?xi32>
 // KERNEL-NEXT:     return %0 : i32
 // KERNEL-NEXT:   }
 // KERNEL-NEXT: }
 
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// HYPERBLOCK-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -490,9 +490,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %4, %arg11[%arg14] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -510,9 +510,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %6, %arg12[%arg15] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -534,9 +534,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg13 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg13 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -550,9 +550,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %3, %arg11[%arg13] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -568,9 +568,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %5, %arg12[%arg14] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
+// HYPERBLOCK-NEXT:     %0 = affine.load %done_write_1[0] : memref<?xi32>
 // HYPERBLOCK-NEXT:     return %0 : i32
 // HYPERBLOCK-NEXT:   }
 // HYPERBLOCK-NEXT: }
@@ -578,7 +578,7 @@ module attributes {} {
 
 // MAP-SPATIAL-TEMPORAL-4x4:     module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -594,9 +594,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -614,9 +614,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -638,9 +638,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -654,9 +654,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -672,16 +672,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %0 = affine.load %done_write_1[0] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return %0 : i32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:}
 
 // MAP-SPATIAL-TEMPORAL-1x1:     module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -697,9 +697,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -717,9 +717,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -741,9 +741,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -757,9 +757,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -775,16 +775,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %0 = affine.load %done_write_1[0] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:}
 
 // MAP-SPATIAL-TEMPORAL-1x2:     module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -800,9 +800,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -820,9 +820,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -844,9 +844,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -860,9 +860,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -878,16 +878,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %0 = affine.load %done_write_1[0] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:}
 
 // MAP-SPATIAL:      module {
 // MAP-SPATIAL-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<?x8x6xi32>) dependency_write_in(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -903,9 +903,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -923,9 +923,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_write_out_1 = taskflow.task @Task_2 dependency_read_in(%dependency_write_out, %dependency_write_out_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) dependency_write_in(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -947,9 +947,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_write_out_2 = taskflow.task @Task_3 dependency_read_in(%arg3 : memref<?x7xi32>) dependency_write_in(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -963,9 +963,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %dependency_write_out_3 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_2 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -981,9 +981,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %0 = affine.load %dependency_write_out_1[0] : memref<?xi32>
+// MAP-SPATIAL-NEXT:     %0 = affine.load %done_write_1[0] : memref<?xi32>
 // MAP-SPATIAL-NEXT:     return %0 : i32
 // MAP-SPATIAL-NEXT:   }
 // MAP-SPATIAL-NEXT: }
@@ -992,7 +992,7 @@ module attributes {} {
 // RESOPT:      module {
 // RESOPT-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // RESOPT-NEXT:     %c0 = arith.constant 0 : index
-// RESOPT-NEXT:     %dependency_write_out = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) dependency_write_in(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 160 : i32} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// RESOPT-NEXT:     %done_write = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 160 : i32} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // RESOPT-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // RESOPT-NEXT:       %c5 = arith.constant 5 : index
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
@@ -1013,9 +1013,9 @@ module attributes {} {
 // RESOPT-NEXT:         neura.store_indexed %9 to [%6 : !neura.data<index, i1>]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// RESOPT-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %dependency_read_out:4, %dependency_write_out_0:2 = taskflow.task @Task_0_Task_2_fused_Task_3_utilfused dependency_read_in(%arg0, %dependency_write_out, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) dependency_write_in(%arg9, %arg7 : memref<?xi32>, memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>), original_write_memrefs(%arg9, %arg7 : memref<?xi32>, memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 5 : i32}, trip_count = 192 : i32} : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) {
+// RESOPT-NEXT:     %done_read:4, %done_write_0:2 = taskflow.task @Task_0_Task_2_fused_Task_3_utilfused will_read(%arg0, %done_write, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) will_write(%arg9, %arg7 : memref<?xi32>, memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>), original_write_memrefs(%arg9, %arg7 : memref<?xi32>, memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 5 : i32}, trip_count = 192 : i32} : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) {
 // RESOPT-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?x7xi32>, %arg14: memref<?xi32>, %arg15: memref<?xi32>):
 // RESOPT-NEXT:       %c6 = arith.constant 6 : index
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
@@ -1049,9 +1049,9 @@ module attributes {} {
 // RESOPT-NEXT:       %c1_5 = arith.constant 1 : index
 // RESOPT-NEXT:       %4 = taskflow.counter from %c0_3 to %c4_4 step %c1_5 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
 // RESOPT-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_3 to %c7 step %c1_5 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       taskflow.yield reads(%arg10, %arg11, %arg12, %arg13 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) writes(%arg14, %arg15 : memref<?xi32>, memref<?xi32>)
+// RESOPT-NEXT:       taskflow.yield done_read(%arg10, %arg11, %arg12, %arg13 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) done_write(%arg14, %arg15 : memref<?xi32>, memref<?xi32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %dependency_write_out_1 = taskflow.task @Task_4 dependency_read_in(%arg4, %dependency_write_out_0#1 : memref<?x9xi32>, memref<?xi32>) dependency_write_in(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 36 : i32} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// RESOPT-NEXT:     %done_write_1 = taskflow.task @Task_4 will_read(%arg4, %done_write_0#1 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 36 : i32} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // RESOPT-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // RESOPT-NEXT:       %c9 = arith.constant 9 : index
 // RESOPT-NEXT:       %c0_2 = arith.constant 0 : index
@@ -1069,9 +1069,9 @@ module attributes {} {
 // RESOPT-NEXT:         neura.store_indexed %7 to [%4 : !neura.data<index, i1>]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       taskflow.yield writes(%arg12 : memref<?xi32>)
+// RESOPT-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %0 = memref.load %dependency_write_out_0#0[%c0] : memref<?xi32>
+// RESOPT-NEXT:     %0 = memref.load %done_write_0#0[%c0] : memref<?xi32>
 // RESOPT-NEXT:     return %0 : i32
 // RESOPT-NEXT:   }
 // RESOPT-NEXT: }

--- a/test/multi-cgra/taskflow/multi-nested/multi-nested.mlir
+++ b/test/multi-cgra/taskflow/multi-nested/multi-nested.mlir
@@ -238,7 +238,7 @@ module attributes {} {
 
 // TASKFLOW:      module {
 // TASKFLOW-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// TASKFLOW-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<?x8x6xi32>) will_writes(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg12 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg13 = 0 to 8 {
@@ -248,9 +248,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_writes(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg13 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg14 = 0 to 8 {
@@ -262,9 +262,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes, %done_writes_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_writes(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg14 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg15 = 0 to 8 {
@@ -278,9 +278,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg13 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg13 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_writes_2 = taskflow.task @Task_3 will_reads(%arg3 : memref<?x7xi32>) will_writes(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg12 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg13 = 0 to 7 {
@@ -288,9 +288,9 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %1, %arg11[%arg13] : memref<?xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// TASKFLOW-NEXT:     %done_writes_3 = taskflow.task @Task_4 will_reads(%arg4, %done_writes_2 : memref<?x9xi32>, memref<?xi32>) will_writes(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // TASKFLOW-NEXT:       affine.for %arg13 = 0 to 4 {
 // TASKFLOW-NEXT:         affine.for %arg14 = 0 to 9 {
@@ -300,16 +300,16 @@ module attributes {} {
 // TASKFLOW-NEXT:           affine.store %3, %arg12[%arg14] : memref<?xi32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %0 = affine.load %done_write_1[0] : memref<?xi32>
+// TASKFLOW-NEXT:     %0 = affine.load %done_writes_1[0] : memref<?xi32>
 // TASKFLOW-NEXT:     return %0 : i32
 // TASKFLOW-NEXT:   }
 // TASKFLOW-NEXT: }
 
 // STREAM:      module {
 // STREAM-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// STREAM-NEXT:     %done_write = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// STREAM-NEXT:     %done_writes = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_writes(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg13 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg14 = 0 to 8 {
@@ -321,9 +321,9 @@ module attributes {} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %done_read:3, %done_write_0 = taskflow.task @Task_0_Task_2_fused will_read(%arg0, %done_write, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
+// STREAM-NEXT:     %done_reads:3, %done_writes_0 = taskflow.task @Task_0_Task_2_fused will_reads(%arg0, %done_writes, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) will_writes(%arg9 : memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg14 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg15 = 0 to 8 {
@@ -337,9 +337,9 @@ module attributes {} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_read(%arg10, %arg11, %arg12 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) done_write(%arg12 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield done_reads(%arg10, %arg11, %arg12 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>) done_writes(%arg12 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %done_write_1 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// STREAM-NEXT:     %done_writes_1 = taskflow.task @Task_3 will_reads(%arg3 : memref<?x7xi32>) will_writes(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg12 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg13 = 0 to 7 {
@@ -347,9 +347,9 @@ module attributes {} {
 // STREAM-NEXT:           affine.store %1, %arg11[%arg13] : memref<?xi32>
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %done_write_2 = taskflow.task @Task_4 will_read(%arg4, %done_write_1 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// STREAM-NEXT:     %done_writes_2 = taskflow.task @Task_4 will_reads(%arg4, %done_writes_1 : memref<?x9xi32>, memref<?xi32>) will_writes(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // STREAM-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // STREAM-NEXT:       affine.for %arg13 = 0 to 4 {
 // STREAM-NEXT:         affine.for %arg14 = 0 to 9 {
@@ -359,16 +359,16 @@ module attributes {} {
 // STREAM-NEXT:           affine.store %3, %arg12[%arg14] : memref<?xi32>
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %0 = affine.load %done_write_0[0] : memref<?xi32>
+// STREAM-NEXT:     %0 = affine.load %done_writes_0[0] : memref<?xi32>
 // STREAM-NEXT:     return %0 : i32
 // STREAM-NEXT:   }
 // STREAM-NEXT: }
 
 // KERNEL:      module {
 // KERNEL-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// KERNEL-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<?x8x6xi32>) will_writes(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg12 = 0 to 4 {
 // KERNEL-NEXT:         affine.for %arg13 = 0 to 8 {
@@ -385,9 +385,9 @@ module attributes {} {
 // KERNEL-NEXT:           }
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_writes(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg13 = 0 to 4 {
 // KERNEL-NEXT:         affine.for %arg14 = 0 to 8 {
@@ -406,9 +406,9 @@ module attributes {} {
 // KERNEL-NEXT:           }
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes, %done_writes_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_writes(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg14 = 0 to 4 {
 // KERNEL-NEXT:         affine.for %arg15 = 0 to 8 {
@@ -429,9 +429,9 @@ module attributes {} {
 // KERNEL-NEXT:           }
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield done_write(%arg13 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_writes(%arg13 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_writes_2 = taskflow.task @Task_3 will_reads(%arg3 : memref<?x7xi32>) will_writes(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg12 = 0 to 4 {
 // KERNEL-NEXT:         neura.kernel inputs(%arg10, %arg12, %arg11 : memref<?x7xi32>, index, memref<?xi32>) {
@@ -446,9 +446,9 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// KERNEL-NEXT:     %done_writes_3 = taskflow.task @Task_4 will_reads(%arg4, %done_writes_2 : memref<?x9xi32>, memref<?xi32>) will_writes(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // KERNEL-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // KERNEL-NEXT:       affine.for %arg13 = 0 to 4 {
 // KERNEL-NEXT:         neura.kernel inputs(%arg10, %arg13, %arg11, %arg12 : memref<?x9xi32>, index, memref<?xi32>, memref<?xi32>) {
@@ -465,16 +465,16 @@ module attributes {} {
 // KERNEL-NEXT:           neura.yield
 // KERNEL-NEXT:         }
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// KERNEL-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // KERNEL-NEXT:     }
-// KERNEL-NEXT:     %0 = affine.load %done_write_1[0] : memref<?xi32>
+// KERNEL-NEXT:     %0 = affine.load %done_writes_1[0] : memref<?xi32>
 // KERNEL-NEXT:     return %0 : i32
 // KERNEL-NEXT:   }
 // KERNEL-NEXT: }
 
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// HYPERBLOCK-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<?x8x6xi32>) will_writes(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -490,9 +490,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %4, %arg11[%arg14] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_writes(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -510,9 +510,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %6, %arg12[%arg15] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes, %done_writes_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_writes(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -534,9 +534,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg13 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg13 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_writes_2 = taskflow.task @Task_3 will_reads(%arg3 : memref<?x7xi32>) will_writes(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -550,9 +550,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %3, %arg11[%arg13] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// HYPERBLOCK-NEXT:     %done_writes_3 = taskflow.task @Task_4 will_reads(%arg4, %done_writes_2 : memref<?x9xi32>, memref<?xi32>) will_writes(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c4 = arith.constant 4 : index
@@ -568,9 +568,9 @@ module attributes {} {
 // HYPERBLOCK-NEXT:         memref.store %5, %arg12[%arg14] : memref<?xi32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %0 = affine.load %done_write_1[0] : memref<?xi32>
+// HYPERBLOCK-NEXT:     %0 = affine.load %done_writes_1[0] : memref<?xi32>
 // HYPERBLOCK-NEXT:     return %0 : i32
 // HYPERBLOCK-NEXT:   }
 // HYPERBLOCK-NEXT: }
@@ -578,7 +578,7 @@ module attributes {} {
 
 // MAP-SPATIAL-TEMPORAL-4x4:     module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<?x8x6xi32>) will_writes(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -594,9 +594,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_writes(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -614,9 +614,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes, %done_writes_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_writes(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -638,9 +638,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_2 = taskflow.task @Task_3 will_reads(%arg3 : memref<?x7xi32>) will_writes(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -654,9 +654,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_3 = taskflow.task @Task_4 will_reads(%arg4, %done_writes_2 : memref<?x9xi32>, memref<?xi32>) will_writes(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c4 = arith.constant 4 : index
@@ -672,16 +672,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %0 = affine.load %done_write_1[0] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %0 = affine.load %done_writes_1[0] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return %0 : i32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:}
 
 // MAP-SPATIAL-TEMPORAL-1x1:     module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<?x8x6xi32>) will_writes(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -697,9 +697,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_writes(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -717,9 +717,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes, %done_writes_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_writes(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -741,9 +741,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_2 = taskflow.task @Task_3 will_reads(%arg3 : memref<?x7xi32>) will_writes(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -757,9 +757,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_3 = taskflow.task @Task_4 will_reads(%arg4, %done_writes_2 : memref<?x9xi32>, memref<?xi32>) will_writes(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c4 = arith.constant 4 : index
@@ -775,16 +775,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %0 = affine.load %done_write_1[0] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %0 = affine.load %done_writes_1[0] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:}
 
 // MAP-SPATIAL-TEMPORAL-1x2:     module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<?x8x6xi32>) will_writes(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -800,9 +800,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_writes(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -820,9 +820,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes, %done_writes_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_writes(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -844,9 +844,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_2 = taskflow.task @Task_3 will_reads(%arg3 : memref<?x7xi32>) will_writes(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -860,9 +860,9 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_3 = taskflow.task @Task_4 will_reads(%arg4, %done_writes_2 : memref<?x9xi32>, memref<?xi32>) will_writes(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c4 = arith.constant 4 : index
@@ -878,16 +878,16 @@ module attributes {} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %0 = affine.load %done_write_1[0] : memref<?xi32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %0 = affine.load %done_writes_1[0] : memref<?xi32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return %0 : i32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:}
 
 // MAP-SPATIAL:      module {
 // MAP-SPATIAL-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// MAP-SPATIAL-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<?x8x6xi32>) will_write(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<?x8x6xi32>) will_writes(%arg5 : memref<?xi32>) [original_read_memrefs(%arg0 : memref<?x8x6xi32>), original_write_memrefs(%arg5 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?x8x6xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -903,9 +903,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %4, %arg11[%arg14] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_writes(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -923,9 +923,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %6, %arg12[%arg15] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %done_write_1 = taskflow.task @Task_2 will_read(%done_write, %done_write_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_write(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_writes_1 = taskflow.task @Task_2 will_reads(%done_writes, %done_writes_0, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>) will_writes(%arg9 : memref<?xi32>) [original_read_memrefs(%arg5, %arg6, %arg9 : memref<?xi32>, memref<?xi32>, memref<?xi32>), original_write_memrefs(%arg9 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 0 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}, {col = 0 : i32, row = 1 : i32}], write_sram_locations = [{col = 0 : i32, row = 1 : i32}]}} : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -947,9 +947,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %8, %arg13[%c0_5] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg13 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_writes(%arg13 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %done_write_2 = taskflow.task @Task_3 will_read(%arg3 : memref<?x7xi32>) will_write(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_writes_2 = taskflow.task @Task_3 will_reads(%arg3 : memref<?x7xi32>) will_writes(%arg7 : memref<?xi32>) [original_read_memrefs(%arg3 : memref<?x7xi32>), original_write_memrefs(%arg7 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 2 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x7xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x7xi32>, %arg11: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -963,9 +963,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %3, %arg11[%arg13] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg11 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_writes(%arg11 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %done_write_3 = taskflow.task @Task_4 will_read(%arg4, %done_write_2 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// MAP-SPATIAL-NEXT:     %done_writes_3 = taskflow.task @Task_4 will_reads(%arg4, %done_writes_2 : memref<?x9xi32>, memref<?xi32>) will_writes(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 3 : i32, row = 0 : i32}, {col = 3 : i32, row = 0 : i32}], write_sram_locations = [{col = 3 : i32, row = 0 : i32}]}} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // MAP-SPATIAL-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // MAP-SPATIAL-NEXT:       %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:       %c4 = arith.constant 4 : index
@@ -981,9 +981,9 @@ module attributes {} {
 // MAP-SPATIAL-NEXT:         memref.store %5, %arg12[%arg14] : memref<?xi32>
 // MAP-SPATIAL-NEXT:         taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:       }) : (index, index) -> ()
-// MAP-SPATIAL-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// MAP-SPATIAL-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // MAP-SPATIAL-NEXT:     }
-// MAP-SPATIAL-NEXT:     %0 = affine.load %done_write_1[0] : memref<?xi32>
+// MAP-SPATIAL-NEXT:     %0 = affine.load %done_writes_1[0] : memref<?xi32>
 // MAP-SPATIAL-NEXT:     return %0 : i32
 // MAP-SPATIAL-NEXT:   }
 // MAP-SPATIAL-NEXT: }
@@ -992,7 +992,7 @@ module attributes {} {
 // RESOPT:      module {
 // RESOPT-NEXT:   func.func @_Z21pureNestedLoopExamplePA8_A6_iPA8_A5_iS4_PA7_iPA9_iPiS9_S9_S9_S9_(%arg0: memref<?x8x6xi32>, %arg1: memref<?x8x5xi32>, %arg2: memref<?x8x5xi32>, %arg3: memref<?x7xi32>, %arg4: memref<?x9xi32>, %arg5: memref<?xi32>, %arg6: memref<?xi32>, %arg7: memref<?xi32>, %arg8: memref<?xi32>, %arg9: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // RESOPT-NEXT:     %c0 = arith.constant 0 : index
-// RESOPT-NEXT:     %done_write = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_write(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 160 : i32} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// RESOPT-NEXT:     %done_writes = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>) will_writes(%arg6 : memref<?xi32>) [original_read_memrefs(%arg1, %arg2 : memref<?x8x5xi32>, memref<?x8x5xi32>), original_write_memrefs(%arg6 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 160 : i32} : (memref<?x8x5xi32>, memref<?x8x5xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // RESOPT-NEXT:     ^bb0(%arg10: memref<?x8x5xi32>, %arg11: memref<?x8x5xi32>, %arg12: memref<?xi32>):
 // RESOPT-NEXT:       %c5 = arith.constant 5 : index
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
@@ -1013,9 +1013,9 @@ module attributes {} {
 // RESOPT-NEXT:         neura.store_indexed %9 to [%6 : !neura.data<index, i1>]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// RESOPT-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %done_read:4, %done_write_0:2 = taskflow.task @Task_0_Task_2_fused_Task_3_utilfused will_read(%arg0, %done_write, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) will_write(%arg9, %arg7 : memref<?xi32>, memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>), original_write_memrefs(%arg9, %arg7 : memref<?xi32>, memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 5 : i32}, trip_count = 192 : i32} : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) {
+// RESOPT-NEXT:     %done_reads:4, %done_writes_0:2 = taskflow.task @Task_0_Task_2_fused_Task_3_utilfused will_reads(%arg0, %done_writes, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) will_writes(%arg9, %arg7 : memref<?xi32>, memref<?xi32>) [original_read_memrefs(%arg0, %arg6, %arg9, %arg3 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>), original_write_memrefs(%arg9, %arg7 : memref<?xi32>, memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 5 : i32}, trip_count = 192 : i32} : (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>, memref<?xi32>, memref<?xi32>) {
 // RESOPT-NEXT:     ^bb0(%arg10: memref<?x8x6xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>, %arg13: memref<?x7xi32>, %arg14: memref<?xi32>, %arg15: memref<?xi32>):
 // RESOPT-NEXT:       %c6 = arith.constant 6 : index
 // RESOPT-NEXT:       %c8 = arith.constant 8 : index
@@ -1049,9 +1049,9 @@ module attributes {} {
 // RESOPT-NEXT:       %c1_5 = arith.constant 1 : index
 // RESOPT-NEXT:       %4 = taskflow.counter from %c0_3 to %c4_4 step %c1_5 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
 // RESOPT-NEXT:       %5 = taskflow.counter parent(%4 : index) from %c0_3 to %c7 step %c1_5 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       taskflow.yield done_read(%arg10, %arg11, %arg12, %arg13 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) done_write(%arg14, %arg15 : memref<?xi32>, memref<?xi32>)
+// RESOPT-NEXT:       taskflow.yield done_reads(%arg10, %arg11, %arg12, %arg13 : memref<?x8x6xi32>, memref<?xi32>, memref<?xi32>, memref<?x7xi32>) done_writes(%arg14, %arg15 : memref<?xi32>, memref<?xi32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %done_write_1 = taskflow.task @Task_4 will_read(%arg4, %done_write_0#1 : memref<?x9xi32>, memref<?xi32>) will_write(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 36 : i32} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
+// RESOPT-NEXT:     %done_writes_1 = taskflow.task @Task_4 will_reads(%arg4, %done_writes_0#1 : memref<?x9xi32>, memref<?xi32>) will_writes(%arg8 : memref<?xi32>) [original_read_memrefs(%arg4, %arg7 : memref<?x9xi32>, memref<?xi32>), original_write_memrefs(%arg8 : memref<?xi32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, dlp_replicable = true, profile_info = {duration = 4 : i32}, trip_count = 36 : i32} : (memref<?x9xi32>, memref<?xi32>, memref<?xi32>) -> (memref<?xi32>) {
 // RESOPT-NEXT:     ^bb0(%arg10: memref<?x9xi32>, %arg11: memref<?xi32>, %arg12: memref<?xi32>):
 // RESOPT-NEXT:       %c9 = arith.constant 9 : index
 // RESOPT-NEXT:       %c0_2 = arith.constant 0 : index
@@ -1069,9 +1069,9 @@ module attributes {} {
 // RESOPT-NEXT:         neura.store_indexed %7 to [%4 : !neura.data<index, i1>]  {rhs_value = "%input2"} : !neura.data<i32, i1>
 // RESOPT-NEXT:         neura.yield {yield_type = "void"}
 // RESOPT-NEXT:       }
-// RESOPT-NEXT:       taskflow.yield done_write(%arg12 : memref<?xi32>)
+// RESOPT-NEXT:       taskflow.yield done_writes(%arg12 : memref<?xi32>)
 // RESOPT-NEXT:     }
-// RESOPT-NEXT:     %0 = memref.load %done_write_0#0[%c0] : memref<?xi32>
+// RESOPT-NEXT:     %0 = memref.load %done_writes_0#0[%c0] : memref<?xi32>
 // RESOPT-NEXT:     return %0 : i32
 // RESOPT-NEXT:   }
 // RESOPT-NEXT: }

--- a/test/multi-cgra/taskflow/parallel-nested/parallel-nested.mlir
+++ b/test/multi-cgra/taskflow/parallel-nested/parallel-nested.mlir
@@ -128,16 +128,16 @@ module {
 
 // TASKFLOW:      module {
 // TASKFLOW-NEXT:   func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// TASKFLOW-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// TASKFLOW-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<16xf32>) will_writes(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // TASKFLOW-NEXT:       affine.for %arg8 = 0 to 16 {
 // TASKFLOW-NEXT:         %0 = affine.load %arg6[%arg8] : memref<16xf32>
 // TASKFLOW-NEXT:         %1 = arith.mulf %0, %arg7 : f32
 // TASKFLOW-NEXT:         affine.store %1, %arg6[%arg8] : memref<16xf32>
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg6 : memref<16xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg6 : memref<16xf32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// TASKFLOW-NEXT:     %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_writes(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // TASKFLOW-NEXT:       affine.for %arg8 = 0 to 8 {
 // TASKFLOW-NEXT:         affine.for %arg9 = 0 to 8 {
@@ -147,7 +147,7 @@ module {
 // TASKFLOW-NEXT:           affine.store %2, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg7 : memref<8x8xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg7 : memref<8x8xf32>)
 // TASKFLOW-NEXT:     }
 // TASKFLOW-NEXT:     return
 // TASKFLOW-NEXT:   }
@@ -155,7 +155,7 @@ module {
 
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// HYPERBLOCK-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// HYPERBLOCK-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<16xf32>) will_writes(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c16 = arith.constant 16 : index
@@ -168,9 +168,9 @@ module {
 // HYPERBLOCK-NEXT:         memref.store %2, %arg6[%arg8] : memref<16xf32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg6 : memref<16xf32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg6 : memref<16xf32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// HYPERBLOCK-NEXT:     %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_writes(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c8 = arith.constant 8 : index
@@ -185,7 +185,7 @@ module {
 // HYPERBLOCK-NEXT:         memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg7 : memref<8x8xf32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_writes(%arg7 : memref<8x8xf32>)
 // HYPERBLOCK-NEXT:     }
 // HYPERBLOCK-NEXT:     return
 // HYPERBLOCK-NEXT:   }
@@ -194,7 +194,7 @@ module {
 
 // MAP-SPATIAL-TEMPORAL-4x4:     module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<16xf32>) will_writes(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c16 = arith.constant 16 : index
@@ -207,9 +207,9 @@ module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_writes(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c8 = arith.constant 8 : index
@@ -224,7 +224,7 @@ module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  }
@@ -232,7 +232,7 @@ module {
 
 // MAP-SPATIAL-TEMPORAL-1x1:     module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<16xf32>) will_writes(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c16 = arith.constant 16 : index
@@ -245,9 +245,9 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_writes(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c8 = arith.constant 8 : index
@@ -262,7 +262,7 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  }
@@ -270,7 +270,7 @@ module {
 
 // MAP-SPATIAL-TEMPORAL-1x2:     module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<16xf32>) will_writes(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c16 = arith.constant 16 : index
@@ -283,9 +283,9 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_writes(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c8 = arith.constant 8 : index
@@ -300,7 +300,7 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  }
@@ -308,7 +308,7 @@ module {
 
 // MAP-SPATIAL:     module {
 // MAP-SPATIAL-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// MAP-SPATIAL-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<16xf32>) will_writes(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:      %c16 = arith.constant 16 : index
@@ -321,9 +321,9 @@ module {
 // MAP-SPATIAL-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-NEXT:      taskflow.yield done_write(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-NEXT:      taskflow.yield done_writes(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-NEXT:    }
-// MAP-SPATIAL-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// MAP-SPATIAL-NEXT:    %done_writes_0 = taskflow.task @Task_1 will_reads(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_writes(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:      %c8 = arith.constant 8 : index
@@ -338,7 +338,7 @@ module {
 // MAP-SPATIAL-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-NEXT:      taskflow.yield done_write(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-NEXT:      taskflow.yield done_writes(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-NEXT:    }
 // MAP-SPATIAL-NEXT:    return
 // MAP-SPATIAL-NEXT:  }
@@ -347,7 +347,7 @@ module {
 
 // RESOPT:      module {
 // RESOPT-NEXT:   func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// RESOPT-NEXT:     %done_read:3, %done_write:2 = taskflow.task @Task_0_Task_1_utilfused will_read(%arg0, %arg1, %arg2 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>) will_write(%arg0, %arg3 : memref<16xf32>, memref<8x8xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0, %arg1, %arg2 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg0, %arg3 : memref<16xf32>, memref<8x8xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 4 : i32}, trip_count = 64 : i32} : (memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>, memref<16xf32>, memref<8x8xf32>, f32) -> (memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>, memref<16xf32>, memref<8x8xf32>) {
+// RESOPT-NEXT:     %done_reads:3, %done_writes:2 = taskflow.task @Task_0_Task_1_utilfused will_reads(%arg0, %arg1, %arg2 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>) will_writes(%arg0, %arg3 : memref<16xf32>, memref<8x8xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0, %arg1, %arg2 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg0, %arg3 : memref<16xf32>, memref<8x8xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 4 : i32}, trip_count = 64 : i32} : (memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>, memref<16xf32>, memref<8x8xf32>, f32) -> (memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>, memref<16xf32>, memref<8x8xf32>) {
 // RESOPT-NEXT:     ^bb0(%arg5: memref<16xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>, %arg8: memref<16xf32>, %arg9: memref<8x8xf32>, %arg10: f32):
 // RESOPT-NEXT:       %c0 = arith.constant 0 : index
 // RESOPT-NEXT:       %c16 = arith.constant 16 : index
@@ -372,7 +372,7 @@ module {
 // RESOPT-NEXT:       %c1_1 = arith.constant 1 : index
 // RESOPT-NEXT:       %1 = taskflow.counter from %c0_0 to %c8 step %c1_1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
 // RESOPT-NEXT:       %2 = taskflow.counter parent(%1 : index) from %c0_0 to %c8 step %c1_1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       taskflow.yield done_read(%arg5, %arg6, %arg7 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>) done_write(%arg8, %arg9 : memref<16xf32>, memref<8x8xf32>)
+// RESOPT-NEXT:       taskflow.yield done_reads(%arg5, %arg6, %arg7 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>) done_writes(%arg8, %arg9 : memref<16xf32>, memref<8x8xf32>)
 // RESOPT-NEXT:     }
 // RESOPT-NEXT:     return
 // RESOPT-NEXT:   }

--- a/test/multi-cgra/taskflow/parallel-nested/parallel-nested.mlir
+++ b/test/multi-cgra/taskflow/parallel-nested/parallel-nested.mlir
@@ -128,16 +128,16 @@ module {
 
 // TASKFLOW:      module {
 // TASKFLOW-NEXT:   func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// TASKFLOW-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// TASKFLOW-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // TASKFLOW-NEXT:       affine.for %arg8 = 0 to 16 {
 // TASKFLOW-NEXT:         %0 = affine.load %arg6[%arg8] : memref<16xf32>
 // TASKFLOW-NEXT:         %1 = arith.mulf %0, %arg7 : f32
 // TASKFLOW-NEXT:         affine.store %1, %arg6[%arg8] : memref<16xf32>
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg6 : memref<16xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg6 : memref<16xf32>)
 // TASKFLOW-NEXT:     }
-// TASKFLOW-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// TASKFLOW-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // TASKFLOW-NEXT:       affine.for %arg8 = 0 to 8 {
 // TASKFLOW-NEXT:         affine.for %arg9 = 0 to 8 {
@@ -147,7 +147,7 @@ module {
 // TASKFLOW-NEXT:           affine.store %2, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg7 : memref<8x8xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg7 : memref<8x8xf32>)
 // TASKFLOW-NEXT:     }
 // TASKFLOW-NEXT:     return
 // TASKFLOW-NEXT:   }
@@ -155,7 +155,7 @@ module {
 
 // HYPERBLOCK:      module {
 // HYPERBLOCK-NEXT:   func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// HYPERBLOCK-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// HYPERBLOCK-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c16 = arith.constant 16 : index
@@ -168,9 +168,9 @@ module {
 // HYPERBLOCK-NEXT:         memref.store %2, %arg6[%arg8] : memref<16xf32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg6 : memref<16xf32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg6 : memref<16xf32>)
 // HYPERBLOCK-NEXT:     }
-// HYPERBLOCK-NEXT:     %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// HYPERBLOCK-NEXT:     %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // HYPERBLOCK-NEXT:     ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // HYPERBLOCK-NEXT:       %c0 = arith.constant 0 : index
 // HYPERBLOCK-NEXT:       %c8 = arith.constant 8 : index
@@ -185,7 +185,7 @@ module {
 // HYPERBLOCK-NEXT:         memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // HYPERBLOCK-NEXT:         taskflow.hyperblock.yield
 // HYPERBLOCK-NEXT:       }) : (index, index) -> ()
-// HYPERBLOCK-NEXT:       taskflow.yield writes(%arg7 : memref<8x8xf32>)
+// HYPERBLOCK-NEXT:       taskflow.yield done_write(%arg7 : memref<8x8xf32>)
 // HYPERBLOCK-NEXT:     }
 // HYPERBLOCK-NEXT:     return
 // HYPERBLOCK-NEXT:   }
@@ -194,7 +194,7 @@ module {
 
 // MAP-SPATIAL-TEMPORAL-4x4:     module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c16 = arith.constant 16 : index
@@ -207,9 +207,9 @@ module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c8 = arith.constant 8 : index
@@ -224,7 +224,7 @@ module {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  }
@@ -232,7 +232,7 @@ module {
 
 // MAP-SPATIAL-TEMPORAL-1x1:     module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c16 = arith.constant 16 : index
@@ -245,9 +245,9 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c8 = arith.constant 8 : index
@@ -262,7 +262,7 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  }
@@ -270,7 +270,7 @@ module {
 
 // MAP-SPATIAL-TEMPORAL-1x2:     module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c16 = arith.constant 16 : index
@@ -283,9 +283,9 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c8 = arith.constant 8 : index
@@ -300,7 +300,7 @@ module {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  }
@@ -308,7 +308,7 @@ module {
 
 // MAP-SPATIAL:     module {
 // MAP-SPATIAL-NEXT:  func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// MAP-SPATIAL-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<16xf32>) dependency_write_in(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
+// MAP-SPATIAL-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<16xf32>) will_write(%arg0 : memref<16xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0 : memref<16xf32>), original_write_memrefs(%arg0 : memref<16xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<16xf32>, memref<16xf32>, f32) -> (memref<16xf32>) {
 // MAP-SPATIAL-NEXT:    ^bb0(%arg5: memref<16xf32>, %arg6: memref<16xf32>, %arg7: f32):
 // MAP-SPATIAL-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:      %c16 = arith.constant 16 : index
@@ -321,9 +321,9 @@ module {
 // MAP-SPATIAL-NEXT:        memref.store %2, %arg6[%arg8] : memref<16xf32>
 // MAP-SPATIAL-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:      }) : (index) -> ()
-// MAP-SPATIAL-NEXT:      taskflow.yield writes(%arg6 : memref<16xf32>)
+// MAP-SPATIAL-NEXT:      taskflow.yield done_write(%arg6 : memref<16xf32>)
 // MAP-SPATIAL-NEXT:    }
-// MAP-SPATIAL-NEXT:    %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
+// MAP-SPATIAL-NEXT:    %done_write_0 = taskflow.task @Task_1 will_read(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>) will_write(%arg3 : memref<8x8xf32>) [original_read_memrefs(%arg1, %arg2 : memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg3 : memref<8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<8x8xf32>, memref<8x8xf32>, memref<8x8xf32>) -> (memref<8x8xf32>) {
 // MAP-SPATIAL-NEXT:    ^bb0(%arg5: memref<8x8xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>):
 // MAP-SPATIAL-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-NEXT:      %c8 = arith.constant 8 : index
@@ -338,7 +338,7 @@ module {
 // MAP-SPATIAL-NEXT:        memref.store %4, %arg7[%arg8, %arg9] : memref<8x8xf32>
 // MAP-SPATIAL-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-NEXT:      }) : (index, index) -> ()
-// MAP-SPATIAL-NEXT:      taskflow.yield writes(%arg7 : memref<8x8xf32>)
+// MAP-SPATIAL-NEXT:      taskflow.yield done_write(%arg7 : memref<8x8xf32>)
 // MAP-SPATIAL-NEXT:    }
 // MAP-SPATIAL-NEXT:    return
 // MAP-SPATIAL-NEXT:  }
@@ -347,7 +347,7 @@ module {
 
 // RESOPT:      module {
 // RESOPT-NEXT:   func.func @parallel_nested_example(%arg0: memref<16xf32>, %arg1: memref<8x8xf32>, %arg2: memref<8x8xf32>, %arg3: memref<8x8xf32>, %arg4: f32) {
-// RESOPT-NEXT:     %dependency_read_out:3, %dependency_write_out:2 = taskflow.task @Task_0_Task_1_utilfused dependency_read_in(%arg0, %arg1, %arg2 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>) dependency_write_in(%arg0, %arg3 : memref<16xf32>, memref<8x8xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0, %arg1, %arg2 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg0, %arg3 : memref<16xf32>, memref<8x8xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 4 : i32}, trip_count = 64 : i32} : (memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>, memref<16xf32>, memref<8x8xf32>, f32) -> (memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>, memref<16xf32>, memref<8x8xf32>) {
+// RESOPT-NEXT:     %done_read:3, %done_write:2 = taskflow.task @Task_0_Task_1_utilfused will_read(%arg0, %arg1, %arg2 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>) will_write(%arg0, %arg3 : memref<16xf32>, memref<8x8xf32>) value_inputs(%arg4 : f32) [original_read_memrefs(%arg0, %arg1, %arg2 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>), original_write_memrefs(%arg0, %arg3 : memref<16xf32>, memref<8x8xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 2 : i32, profile_info = {duration = 4 : i32}, trip_count = 64 : i32} : (memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>, memref<16xf32>, memref<8x8xf32>, f32) -> (memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>, memref<16xf32>, memref<8x8xf32>) {
 // RESOPT-NEXT:     ^bb0(%arg5: memref<16xf32>, %arg6: memref<8x8xf32>, %arg7: memref<8x8xf32>, %arg8: memref<16xf32>, %arg9: memref<8x8xf32>, %arg10: f32):
 // RESOPT-NEXT:       %c0 = arith.constant 0 : index
 // RESOPT-NEXT:       %c16 = arith.constant 16 : index
@@ -372,7 +372,7 @@ module {
 // RESOPT-NEXT:       %c1_1 = arith.constant 1 : index
 // RESOPT-NEXT:       %1 = taskflow.counter from %c0_0 to %c8 step %c1_1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "root", counter_id = 0 : i32} : index
 // RESOPT-NEXT:       %2 = taskflow.counter parent(%1 : index) from %c0_0 to %c8 step %c1_1 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 1 : i32} : index
-// RESOPT-NEXT:       taskflow.yield reads(%arg5, %arg6, %arg7 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>) writes(%arg8, %arg9 : memref<16xf32>, memref<8x8xf32>)
+// RESOPT-NEXT:       taskflow.yield done_read(%arg5, %arg6, %arg7 : memref<16xf32>, memref<8x8xf32>, memref<8x8xf32>) done_write(%arg8, %arg9 : memref<16xf32>, memref<8x8xf32>)
 // RESOPT-NEXT:     }
 // RESOPT-NEXT:     return
 // RESOPT-NEXT:   }

--- a/test/multi-cgra/taskflow/resnet/simple_resnet_tosa.mlir
+++ b/test/multi-cgra/taskflow/resnet/simple_resnet_tosa.mlir
@@ -262,7 +262,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // AFFINE-NEXT:   }
 // AFFINE-NEXT: }
 
-// KERNEL:          %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {dlp_replicable = true} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// KERNEL:          %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {dlp_replicable = true} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // KERNEL-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // KERNEL-NEXT:       %c64 = arith.constant 64 : index
 // KERNEL-NEXT:       %c8 = arith.constant 8 : index
@@ -286,7 +286,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // KERNEL-NEXT:         memref.store %8, %arg4[%4, %5, %6, %7] : memref<1x8x8x64xf32>
 // KERNEL-NEXT:         neura.yield
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
+// KERNEL-NEXT:       taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
 // KERNEL-NEXT:     }
 
 
@@ -300,7 +300,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:     %cst_1 = arith.constant 3.40282347E+38 : f32
 // STREAM-NEXT:     %cst_2 = arith.constant 0.000000e+00 : f32
 // STREAM-NEXT:     %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -312,10 +312,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// STREAM-NEXT:     %dependency_write_out_4 = taskflow.task @Task_1 dependency_write_in(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// STREAM-NEXT:     %done_write_4 = taskflow.task @Task_1 will_write(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 10 {
@@ -326,10 +326,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %dependency_write_out_6 = taskflow.task @Task_2 dependency_write_in(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_write_6 = taskflow.task @Task_2 will_write(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -340,9 +340,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_write_7 = taskflow.task @Task_3 will_read(%done_write_4, %done_write_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // STREAM-NEXT:       affine.for %arg5 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg6 = 0 to 8 {
@@ -363,10 +363,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// STREAM-NEXT:     %dependency_read_out, %dependency_write_out_9 = taskflow.task @Task_4_Task_5_fused dependency_read_in(%dependency_write_out_7 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_8 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
+// STREAM-NEXT:     %done_read, %done_write_9 = taskflow.task @Task_4_Task_5_fused will_read(%done_write_7 : memref<1x8x8x64xf32>) will_write(%alloc_8 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // STREAM-NEXT:       affine.for %arg5 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg6 = 0 to 64 {
@@ -380,10 +380,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg1 : memref<1x8x8x64xf32>) writes(%arg2 : memref<1x64x8x8xf32>)
+// STREAM-NEXT:       taskflow.yield done_read(%arg1 : memref<1x8x8x64xf32>) done_write(%arg2 : memref<1x64x8x8xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %dependency_write_out_11 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_9 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_10 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_write_11 = taskflow.task @Task_6 will_read(%done_write_9 : memref<1x64x8x8xf32>) will_write(%alloc_10 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -395,10 +395,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// STREAM-NEXT:     %dependency_write_out_13 = taskflow.task @Task_7 dependency_write_in(%alloc_12 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_12 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// STREAM-NEXT:     %done_write_13 = taskflow.task @Task_7 will_write(%alloc_12 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_12 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 10 {
@@ -409,10 +409,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %dependency_write_out_15 = taskflow.task @Task_8 dependency_write_in(%alloc_14 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_write_15 = taskflow.task @Task_8 will_write(%alloc_14 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -423,9 +423,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %dependency_write_out_16 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_13, %dependency_write_out_15 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_15 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_12, %alloc_14 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_write_16 = taskflow.task @Task_9 will_read(%done_write_13, %done_write_15 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_15 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_12, %alloc_14 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // STREAM-NEXT:       affine.for %arg5 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg6 = 0 to 8 {
@@ -446,10 +446,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_17 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// STREAM-NEXT:     %dependency_read_out_18:2, %dependency_write_out_19 = taskflow.task @Task_10_Task_11_Task_12_fused_fused dependency_read_in(%dependency_write_out_16, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_17 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_14, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_17 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// STREAM-NEXT:     %done_read_18:2, %done_write_19 = taskflow.task @Task_10_Task_11_Task_12_fused_fused will_read(%done_write_16, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) will_write(%alloc_17 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_14, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_17 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>, %arg4: f32, %arg5: f32):
 // STREAM-NEXT:       affine.for %arg6 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg7 = 0 to 64 {
@@ -465,9 +465,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield reads(%arg1, %arg2 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) writes(%arg3 : memref<1x64x8x8xf32>)
+// STREAM-NEXT:       taskflow.yield done_read(%arg1, %arg2 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) done_write(%arg3 : memref<1x64x8x8xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     return %dependency_write_out_19 : memref<1x64x8x8xf32>
+// STREAM-NEXT:     return %done_write_19 : memref<1x64x8x8xf32>
 // STREAM-NEXT:   }
 // STREAM-NEXT: }
 
@@ -481,7 +481,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %cst_1 = arith.constant 3.40282347E+38 : f32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %cst_2 = arith.constant 0.000000e+00 : f32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 0 : i32, row = 2 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 0 : i32, row = 2 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -497,10 +497,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_4 = taskflow.task @Task_1 dependency_write_in(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_4 = taskflow.task @Task_1 will_write(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -515,10 +515,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_6 = taskflow.task @Task_2 dependency_write_in(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_6 = taskflow.task @Task_2 will_write(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -533,9 +533,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_7 = taskflow.task @Task_3 will_read(%done_write_4, %done_write_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -560,10 +560,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_9 = taskflow.task @Task_4 dependency_read_in(%dependency_write_out_7 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 2 : i32, row = 2 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_9 = taskflow.task @Task_4 will_read(%done_write_7 : memref<1x8x8x64xf32>) will_write(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 2 : i32, row = 2 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -579,10 +579,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_11 = taskflow.task @Task_5 dependency_read_in(%dependency_write_out_9 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 2 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_11 = taskflow.task @Task_5 will_read(%done_write_9 : memref<1x64x8x8xf32>) will_write(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 2 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -600,10 +600,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_13 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_13 = taskflow.task @Task_6 will_read(%done_write_11 : memref<1x64x8x8xf32>) will_write(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -619,10 +619,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_15 = taskflow.task @Task_7 dependency_write_in(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_15 = taskflow.task @Task_7 will_write(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -637,10 +637,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_17 = taskflow.task @Task_8 dependency_write_in(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_17 = taskflow.task @Task_8 will_write(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -655,9 +655,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_18 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_15, %dependency_write_out_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}, {col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_18 = taskflow.task @Task_9 will_read(%done_write_15, %done_write_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}, {col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -682,10 +682,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_20 = taskflow.task @Task_10 dependency_read_in(%dependency_write_out_18 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 3 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_20 = taskflow.task @Task_10 will_read(%done_write_18 : memref<1x8x8x64xf32>) will_write(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 3 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -701,10 +701,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_22 = taskflow.task @Task_11 dependency_read_in(%dependency_write_out_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 3 : i32, row = 3 : i32}, {col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_22 = taskflow.task @Task_11 will_read(%done_write_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) will_write(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 3 : i32, row = 3 : i32}, {col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -722,10 +722,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg3[%arg4, %arg5, %arg6, %arg7] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg3 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg3 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_23 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %dependency_write_out_24 = taskflow.task @Task_12 dependency_read_in(%dependency_write_out_22 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 1 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_24 = taskflow.task @Task_12 will_read(%done_write_22 : memref<1x64x8x8xf32>) will_write(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 1 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -743,9 +743,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return %dependency_write_out_24 : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return %done_write_24 : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:}
 
@@ -759,7 +759,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %cst_1 = arith.constant 3.40282347E+38 : f32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %cst_2 = arith.constant 0.000000e+00 : f32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 10 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 10 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -775,10 +775,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_4 = taskflow.task @Task_1 dependency_write_in(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_4 = taskflow.task @Task_1 will_write(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -793,10 +793,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_6 = taskflow.task @Task_2 dependency_write_in(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_6 = taskflow.task @Task_2 will_write(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -811,9 +811,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_7 = taskflow.task @Task_3 will_read(%done_write_4, %done_write_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -838,10 +838,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_9 = taskflow.task @Task_4 dependency_read_in(%dependency_write_out_7 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_9 = taskflow.task @Task_4 will_read(%done_write_7 : memref<1x8x8x64xf32>) will_write(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -857,10 +857,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_11 = taskflow.task @Task_5 dependency_read_in(%dependency_write_out_9 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 8 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_11 = taskflow.task @Task_5 will_read(%done_write_9 : memref<1x64x8x8xf32>) will_write(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 8 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -878,10 +878,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_13 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 11 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_13 = taskflow.task @Task_6 will_read(%done_write_11 : memref<1x64x8x8xf32>) will_write(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 11 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -897,10 +897,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_15 = taskflow.task @Task_7 dependency_write_in(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_15 = taskflow.task @Task_7 will_write(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -915,10 +915,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_17 = taskflow.task @Task_8 dependency_write_in(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_17 = taskflow.task @Task_8 will_write(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -933,9 +933,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_18 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_15, %dependency_write_out_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_18 = taskflow.task @Task_9 will_read(%done_write_15, %done_write_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -960,10 +960,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_20 = taskflow.task @Task_10 dependency_read_in(%dependency_write_out_18 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 7 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_20 = taskflow.task @Task_10 will_read(%done_write_18 : memref<1x8x8x64xf32>) will_write(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 7 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -979,10 +979,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_22 = taskflow.task @Task_11 dependency_read_in(%dependency_write_out_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 9 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_22 = taskflow.task @Task_11 will_read(%done_write_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) will_write(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 9 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -1000,10 +1000,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg3[%arg4, %arg5, %arg6, %arg7] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg3 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg3 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_23 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %dependency_write_out_24 = taskflow.task @Task_12 dependency_read_in(%dependency_write_out_22 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 12 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_24 = taskflow.task @Task_12 will_read(%done_write_22 : memref<1x64x8x8xf32>) will_write(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 12 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -1021,9 +1021,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return %dependency_write_out_24 : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return %done_write_24 : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:}
 
@@ -1037,7 +1037,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %cst_1 = arith.constant 3.40282347E+38 : f32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %cst_2 = arith.constant 0.000000e+00 : f32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out = taskflow.task @Task_0 dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1053,10 +1053,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_4 = taskflow.task @Task_1 dependency_write_in(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_4 = taskflow.task @Task_1 will_write(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1071,10 +1071,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_6 = taskflow.task @Task_2 dependency_write_in(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_6 = taskflow.task @Task_2 will_write(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1089,9 +1089,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%dependency_write_out_4, %dependency_write_out_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_7 = taskflow.task @Task_3 will_read(%done_write_4, %done_write_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1116,10 +1116,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_9 = taskflow.task @Task_4 dependency_read_in(%dependency_write_out_7 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_9 = taskflow.task @Task_4 will_read(%done_write_7 : memref<1x8x8x64xf32>) will_write(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1135,10 +1135,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_11 = taskflow.task @Task_5 dependency_read_in(%dependency_write_out_9 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_11 = taskflow.task @Task_5 will_read(%done_write_9 : memref<1x64x8x8xf32>) will_write(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1156,10 +1156,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_13 = taskflow.task @Task_6 dependency_read_in(%dependency_write_out_11 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_13 = taskflow.task @Task_6 will_read(%done_write_11 : memref<1x64x8x8xf32>) will_write(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1175,10 +1175,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_15 = taskflow.task @Task_7 dependency_write_in(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_15 = taskflow.task @Task_7 will_write(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1193,10 +1193,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_17 = taskflow.task @Task_8 dependency_write_in(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_17 = taskflow.task @Task_8 will_write(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1211,9 +1211,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_18 = taskflow.task @Task_9 dependency_read_in(%dependency_write_out_15, %dependency_write_out_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) dependency_write_in(%dependency_write_out_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_18 = taskflow.task @Task_9 will_read(%done_write_15, %done_write_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1238,10 +1238,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_20 = taskflow.task @Task_10 dependency_read_in(%dependency_write_out_18 : memref<1x8x8x64xf32>) dependency_write_in(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_20 = taskflow.task @Task_10 will_read(%done_write_18 : memref<1x8x8x64xf32>) will_write(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1257,10 +1257,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_22 = taskflow.task @Task_11 dependency_read_in(%dependency_write_out_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) dependency_write_in(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_22 = taskflow.task @Task_11 will_read(%done_write_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) will_write(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1278,10 +1278,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg3[%arg4, %arg5, %arg6, %arg7] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg3 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg3 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_23 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %dependency_write_out_24 = taskflow.task @Task_12 dependency_read_in(%dependency_write_out_22 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_24 = taskflow.task @Task_12 will_read(%done_write_22 : memref<1x64x8x8xf32>) will_write(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1299,13 +1299,13 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield writes(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return %dependency_write_out_24 : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return %done_write_24 : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:}
 
-// RESOPT:          %dependency_read_out, %dependency_write_out:3 = taskflow.task @Task_1_Task_0_Task_2_utilfused_utilfused dependency_read_in(%arg0 : memref<1x64x8x8xf32>) dependency_write_in(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 5 : i32, profile_info = {duration = 3 : i32}, trip_count = 6400 : i32} : (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// RESOPT:          %done_read, %done_write:3 = taskflow.task @Task_1_Task_0_Task_2_utilfused_utilfused will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 5 : i32, profile_info = {duration = 3 : i32}, trip_count = 6400 : i32} : (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
 // RESOPT-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x10x10x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: memref<1x8x8x64xf32>, %arg5: f32):
 // RESOPT-NEXT:       %c64 = arith.constant 64 : index
 // RESOPT-NEXT:       %c10 = arith.constant 10 : index
@@ -1353,5 +1353,5 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // RESOPT-NEXT:       %9 = taskflow.counter parent(%8 : index) from %c0_23 to %c8_22 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
 // RESOPT-NEXT:       %10 = taskflow.counter parent(%9 : index) from %c0_23 to %c8_22 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 2 : i32} : index
 // RESOPT-NEXT:       %11 = taskflow.counter parent(%10 : index) from %c0_23 to %c64_21 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 3 : i32} : index
-// RESOPT-NEXT:       taskflow.yield reads(%arg1 : memref<1x64x8x8xf32>) writes(%arg2, %arg3, %arg4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)
+// RESOPT-NEXT:       taskflow.yield done_read(%arg1 : memref<1x64x8x8xf32>) done_write(%arg2, %arg3, %arg4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)
 // RESOPT-NEXT:     }

--- a/test/multi-cgra/taskflow/resnet/simple_resnet_tosa.mlir
+++ b/test/multi-cgra/taskflow/resnet/simple_resnet_tosa.mlir
@@ -262,7 +262,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // AFFINE-NEXT:   }
 // AFFINE-NEXT: }
 
-// KERNEL:          %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {dlp_replicable = true} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// KERNEL:          %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<1x64x8x8xf32>) will_writes(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {dlp_replicable = true} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // KERNEL-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // KERNEL-NEXT:       %c64 = arith.constant 64 : index
 // KERNEL-NEXT:       %c8 = arith.constant 8 : index
@@ -286,7 +286,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // KERNEL-NEXT:         memref.store %8, %arg4[%4, %5, %6, %7] : memref<1x8x8x64xf32>
 // KERNEL-NEXT:         neura.yield
 // KERNEL-NEXT:       }
-// KERNEL-NEXT:       taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
+// KERNEL-NEXT:       taskflow.yield done_writes(%arg2 : memref<1x8x8x64xf32>)
 // KERNEL-NEXT:     }
 
 
@@ -300,7 +300,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:     %cst_1 = arith.constant 3.40282347E+38 : f32
 // STREAM-NEXT:     %cst_2 = arith.constant 0.000000e+00 : f32
 // STREAM-NEXT:     %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<1x64x8x8xf32>) will_writes(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -312,10 +312,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg2 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// STREAM-NEXT:     %done_write_4 = taskflow.task @Task_1 will_write(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// STREAM-NEXT:     %done_writes_4 = taskflow.task @Task_1 will_writes(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 10 {
@@ -326,10 +326,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg1 : memref<1x10x10x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %done_write_6 = taskflow.task @Task_2 will_write(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_writes_6 = taskflow.task @Task_2 will_writes(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -340,9 +340,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg1 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %done_write_7 = taskflow.task @Task_3 will_read(%done_write_4, %done_write_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_writes_7 = taskflow.task @Task_3 will_reads(%done_writes_4, %done_writes_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_writes(%done_writes_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // STREAM-NEXT:       affine.for %arg5 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg6 = 0 to 8 {
@@ -363,10 +363,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg3 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// STREAM-NEXT:     %done_read, %done_write_9 = taskflow.task @Task_4_Task_5_fused will_read(%done_write_7 : memref<1x8x8x64xf32>) will_write(%alloc_8 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
+// STREAM-NEXT:     %done_reads, %done_writes_9 = taskflow.task @Task_4_Task_5_fused will_reads(%done_writes_7 : memref<1x8x8x64xf32>) will_writes(%alloc_8 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // STREAM-NEXT:       affine.for %arg5 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg6 = 0 to 64 {
@@ -380,10 +380,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_read(%arg1 : memref<1x8x8x64xf32>) done_write(%arg2 : memref<1x64x8x8xf32>)
+// STREAM-NEXT:       taskflow.yield done_reads(%arg1 : memref<1x8x8x64xf32>) done_writes(%arg2 : memref<1x64x8x8xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %done_write_11 = taskflow.task @Task_6 will_read(%done_write_9 : memref<1x64x8x8xf32>) will_write(%alloc_10 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_writes_11 = taskflow.task @Task_6 will_reads(%done_writes_9 : memref<1x64x8x8xf32>) will_writes(%alloc_10 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x8x8x64xf32>)] : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -395,10 +395,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg2 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// STREAM-NEXT:     %done_write_13 = taskflow.task @Task_7 will_write(%alloc_12 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_12 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// STREAM-NEXT:     %done_writes_13 = taskflow.task @Task_7 will_writes(%alloc_12 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_12 : memref<1x10x10x64xf32>)] : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 10 {
@@ -409,10 +409,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg1 : memref<1x10x10x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// STREAM-NEXT:     %done_write_15 = taskflow.task @Task_8 will_write(%alloc_14 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_writes_15 = taskflow.task @Task_8 will_writes(%alloc_14 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // STREAM-NEXT:       affine.for %arg3 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg4 = 0 to 8 {
@@ -423,9 +423,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg1 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     %done_write_16 = taskflow.task @Task_9 will_read(%done_write_13, %done_write_15 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_15 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_12, %alloc_14 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// STREAM-NEXT:     %done_writes_16 = taskflow.task @Task_9 will_reads(%done_writes_13, %done_writes_15 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_writes(%done_writes_15 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_12, %alloc_14 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_14 : memref<1x8x8x64xf32>)] : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // STREAM-NEXT:       affine.for %arg5 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg6 = 0 to 8 {
@@ -446,10 +446,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
+// STREAM-NEXT:       taskflow.yield done_writes(%arg3 : memref<1x8x8x64xf32>)
 // STREAM-NEXT:     }
 // STREAM-NEXT:     %alloc_17 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// STREAM-NEXT:     %done_read_18:2, %done_write_19 = taskflow.task @Task_10_Task_11_Task_12_fused_fused will_read(%done_write_16, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) will_write(%alloc_17 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_14, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_17 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
+// STREAM-NEXT:     %done_reads_18:2, %done_writes_19 = taskflow.task @Task_10_Task_11_Task_12_fused_fused will_reads(%done_writes_16, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) will_writes(%alloc_17 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_14, %arg0 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_17 : memref<1x64x8x8xf32>)] : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) {
 // STREAM-NEXT:     ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>, %arg4: f32, %arg5: f32):
 // STREAM-NEXT:       affine.for %arg6 = 0 to 1 {
 // STREAM-NEXT:         affine.for %arg7 = 0 to 64 {
@@ -465,9 +465,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // STREAM-NEXT:           }
 // STREAM-NEXT:         }
 // STREAM-NEXT:       }
-// STREAM-NEXT:       taskflow.yield done_read(%arg1, %arg2 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) done_write(%arg3 : memref<1x64x8x8xf32>)
+// STREAM-NEXT:       taskflow.yield done_reads(%arg1, %arg2 : memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) done_writes(%arg3 : memref<1x64x8x8xf32>)
 // STREAM-NEXT:     }
-// STREAM-NEXT:     return %done_write_19 : memref<1x64x8x8xf32>
+// STREAM-NEXT:     return %done_writes_19 : memref<1x64x8x8xf32>
 // STREAM-NEXT:   }
 // STREAM-NEXT: }
 
@@ -481,7 +481,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %cst_1 = arith.constant 3.40282347E+38 : f32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %cst_2 = arith.constant 0.000000e+00 : f32
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 0 : i32, row = 2 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<1x64x8x8xf32>) will_writes(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 0 : i32, row = 2 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -497,10 +497,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_4 = taskflow.task @Task_1 will_write(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_4 = taskflow.task @Task_1 will_writes(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -515,10 +515,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_6 = taskflow.task @Task_2 will_write(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_6 = taskflow.task @Task_2 will_writes(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -533,9 +533,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_7 = taskflow.task @Task_3 will_read(%done_write_4, %done_write_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_7 = taskflow.task @Task_3 will_reads(%done_writes_4, %done_writes_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_writes(%done_writes_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}, {col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 1 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -560,10 +560,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_9 = taskflow.task @Task_4 will_read(%done_write_7 : memref<1x8x8x64xf32>) will_write(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 2 : i32, row = 2 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_9 = taskflow.task @Task_4 will_reads(%done_writes_7 : memref<1x8x8x64xf32>) will_writes(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 1 : i32, row = 1 : i32}], write_sram_locations = [{col = 2 : i32, row = 2 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -579,10 +579,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_11 = taskflow.task @Task_5 will_read(%done_write_9 : memref<1x64x8x8xf32>) will_write(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 2 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_11 = taskflow.task @Task_5 will_reads(%done_writes_9 : memref<1x64x8x8xf32>) will_writes(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 2 : i32, row = 2 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -600,10 +600,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_13 = taskflow.task @Task_6 will_read(%done_write_11 : memref<1x64x8x8xf32>) will_write(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_13 = taskflow.task @Task_6 will_reads(%done_writes_11 : memref<1x64x8x8xf32>) will_writes(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -619,10 +619,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_15 = taskflow.task @Task_7 will_write(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_15 = taskflow.task @Task_7 will_writes(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -637,10 +637,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_17 = taskflow.task @Task_8 will_write(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_17 = taskflow.task @Task_8 will_writes(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -655,9 +655,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_18 = taskflow.task @Task_9 will_read(%done_write_15, %done_write_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}, {col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_18 = taskflow.task @Task_9 will_reads(%done_writes_15, %done_writes_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_writes(%done_writes_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 2 : i32, context_id = 0 : i32, row = 1 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}, {col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 1 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -682,10 +682,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_20 = taskflow.task @Task_10 will_read(%done_write_18 : memref<1x8x8x64xf32>) will_write(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 3 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_20 = taskflow.task @Task_10 will_reads(%done_writes_18 : memref<1x8x8x64xf32>) will_writes(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 2 : i32}], read_sram_locations = [{col = 3 : i32, row = 1 : i32}], write_sram_locations = [{col = 3 : i32, row = 3 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -701,10 +701,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_22 = taskflow.task @Task_11 will_read(%done_write_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) will_write(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 3 : i32, row = 3 : i32}, {col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_22 = taskflow.task @Task_11 will_reads(%done_writes_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) will_writes(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 3 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 3 : i32, row = 3 : i32}, {col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 2 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -722,10 +722,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg3[%arg4, %arg5, %arg6, %arg7] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg3 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg3 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %alloc_23 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_write_24 = taskflow.task @Task_12 will_read(%done_write_22 : memref<1x64x8x8xf32>) will_write(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 1 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    %done_writes_24 = taskflow.task @Task_12 will_reads(%done_writes_22 : memref<1x64x8x8xf32>) will_writes(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 3 : i32}], read_sram_locations = [{col = 2 : i32, row = 3 : i32}], write_sram_locations = [{col = 1 : i32, row = 3 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      %c1 = arith.constant 1 : index
@@ -743,9 +743,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return %done_write_24 : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-4x4-NEXT:    return %done_writes_24 : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-4x4-NEXT:}
 
@@ -759,7 +759,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %cst_1 = arith.constant 3.40282347E+38 : f32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %cst_2 = arith.constant 0.000000e+00 : f32
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 10 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<1x64x8x8xf32>) will_writes(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 10 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -775,10 +775,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_4 = taskflow.task @Task_1 will_write(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_4 = taskflow.task @Task_1 will_writes(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -793,10 +793,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_6 = taskflow.task @Task_2 will_write(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_6 = taskflow.task @Task_2 will_writes(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -811,9 +811,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_7 = taskflow.task @Task_3 will_read(%done_write_4, %done_write_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_7 = taskflow.task @Task_3 will_reads(%done_writes_4, %done_writes_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_writes(%done_writes_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -838,10 +838,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_9 = taskflow.task @Task_4 will_read(%done_write_7 : memref<1x8x8x64xf32>) will_write(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_9 = taskflow.task @Task_4 will_reads(%done_writes_7 : memref<1x8x8x64xf32>) will_writes(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -857,10 +857,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_11 = taskflow.task @Task_5 will_read(%done_write_9 : memref<1x64x8x8xf32>) will_write(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 8 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_11 = taskflow.task @Task_5 will_reads(%done_writes_9 : memref<1x64x8x8xf32>) will_writes(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 8 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -878,10 +878,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_13 = taskflow.task @Task_6 will_read(%done_write_11 : memref<1x64x8x8xf32>) will_write(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 11 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_13 = taskflow.task @Task_6 will_reads(%done_writes_11 : memref<1x64x8x8xf32>) will_writes(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 11 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -897,10 +897,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_15 = taskflow.task @Task_7 will_write(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_15 = taskflow.task @Task_7 will_writes(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -915,10 +915,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_17 = taskflow.task @Task_8 will_write(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_17 = taskflow.task @Task_8 will_writes(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -933,9 +933,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_18 = taskflow.task @Task_9 will_read(%done_write_15, %done_write_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_18 = taskflow.task @Task_9 will_reads(%done_writes_15, %done_writes_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_writes(%done_writes_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -960,10 +960,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_20 = taskflow.task @Task_10 will_read(%done_write_18 : memref<1x8x8x64xf32>) will_write(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 7 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_20 = taskflow.task @Task_10 will_reads(%done_writes_18 : memref<1x8x8x64xf32>) will_writes(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 7 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -979,10 +979,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_22 = taskflow.task @Task_11 will_read(%done_write_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) will_write(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 9 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_22 = taskflow.task @Task_11 will_reads(%done_writes_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) will_writes(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 9 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -1000,10 +1000,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg3[%arg4, %arg5, %arg6, %arg7] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg3 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg3 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %alloc_23 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_write_24 = taskflow.task @Task_12 will_read(%done_write_22 : memref<1x64x8x8xf32>) will_write(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 12 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    %done_writes_24 = taskflow.task @Task_12 will_reads(%done_writes_22 : memref<1x64x8x8xf32>) will_writes(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 12 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      %c1 = arith.constant 1 : index
@@ -1021,9 +1021,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return %done_write_24 : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x1-NEXT:    return %done_writes_24 : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x1-NEXT:}
 
@@ -1037,7 +1037,7 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %cst_1 = arith.constant 3.40282347E+38 : f32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %cst_2 = arith.constant 0.000000e+00 : f32
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write = taskflow.task @Task_0 will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes = taskflow.task @Task_0 will_reads(%arg0 : memref<1x64x8x8xf32>) will_writes(%alloc : memref<1x8x8x64xf32>) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1053,10 +1053,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_4 = taskflow.task @Task_1 will_write(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_4 = taskflow.task @Task_1 will_writes(%alloc_3 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_3 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1071,10 +1071,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_6 = taskflow.task @Task_2 will_write(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_6 = taskflow.task @Task_2 will_writes(%alloc_5 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1089,9 +1089,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_7 = taskflow.task @Task_3 will_read(%done_write_4, %done_write_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_7 = taskflow.task @Task_3 will_reads(%done_writes_4, %done_writes_6 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_writes(%done_writes_6 : memref<1x8x8x64xf32>) value_inputs(%cst_0 : f32) [original_read_memrefs(%alloc_3, %alloc_5 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_5 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}, {col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1116,10 +1116,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_9 = taskflow.task @Task_4 will_read(%done_write_7 : memref<1x8x8x64xf32>) will_write(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_9 = taskflow.task @Task_4 will_reads(%done_writes_7 : memref<1x8x8x64xf32>) will_writes(%alloc_8 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_5 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_8 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 0 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1135,10 +1135,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_11 = taskflow.task @Task_5 will_read(%done_write_9 : memref<1x64x8x8xf32>) will_write(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_11 = taskflow.task @Task_5 will_reads(%done_writes_9 : memref<1x64x8x8xf32>) will_writes(%alloc_10 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_8 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_10 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 0 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1156,10 +1156,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_13 = taskflow.task @Task_6 will_read(%done_write_11 : memref<1x64x8x8xf32>) will_write(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_13 = taskflow.task @Task_6 will_reads(%done_writes_11 : memref<1x64x8x8xf32>) will_writes(%alloc_12 : memref<1x8x8x64xf32>) [original_read_memrefs(%alloc_10 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_12 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 5 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x8x8x64xf32>) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x8x8x64xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1175,10 +1175,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x10x10x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_15 = taskflow.task @Task_7 will_write(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_15 = taskflow.task @Task_7 will_writes(%alloc_14 : memref<1x10x10x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_14 : memref<1x10x10x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, f32) -> (memref<1x10x10x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1193,10 +1193,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x10x10x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg1 : memref<1x10x10x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x10x10x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<1x8x8x64xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_17 = taskflow.task @Task_8 will_write(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_17 = taskflow.task @Task_8 will_writes(%alloc_16 : memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}], read_sram_locations = [], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1211,9 +1211,9 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %arg2, %arg1[%arg3, %arg4, %arg5, %arg6] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg1 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg1 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_18 = taskflow.task @Task_9 will_read(%done_write_15, %done_write_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_write(%done_write_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_18 = taskflow.task @Task_9 will_reads(%done_writes_15, %done_writes_17 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>) will_writes(%done_writes_17 : memref<1x8x8x64xf32>) value_inputs(%cst : f32) [original_read_memrefs(%alloc_14, %alloc_16 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>), original_write_memrefs(%alloc_16 : memref<1x8x8x64xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 2 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x8x8x64xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x10x10x64xf32>, %arg2: memref<1x8x8x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1238,10 +1238,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %12, %arg3[%arg5, %arg6, %arg7, %arg8] : memref<1x8x8x64xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg3 : memref<1x8x8x64xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg3 : memref<1x8x8x64xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_19 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_20 = taskflow.task @Task_10 will_read(%done_write_18 : memref<1x8x8x64xf32>) will_write(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_20 = taskflow.task @Task_10 will_reads(%done_writes_18 : memref<1x8x8x64xf32>) will_writes(%alloc_19 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_16 : memref<1x8x8x64xf32>), original_write_memrefs(%alloc_19 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 3 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x8x8x64xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x8x8x64xf32>, %arg2: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1257,10 +1257,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %4, %arg2[%arg3, %arg4, %arg5, %arg6] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_22 = taskflow.task @Task_11 will_read(%done_write_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) will_write(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_22 = taskflow.task @Task_11 will_reads(%done_writes_20, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) will_writes(%alloc_21 : memref<1x64x8x8xf32>) [original_read_memrefs(%alloc_19, %arg0 : memref<1x64x8x8xf32>, memref<1x64x8x8xf32>), original_write_memrefs(%alloc_21 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 4 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}, {col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, memref<1x64x8x8xf32>) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: memref<1x64x8x8xf32>):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1278,10 +1278,10 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg3[%arg4, %arg5, %arg6, %arg7] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg3 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg3 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %alloc_23 = memref.alloc() {alignment = 64 : i64} : memref<1x64x8x8xf32>
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_write_24 = taskflow.task @Task_12 will_read(%done_write_22 : memref<1x64x8x8xf32>) will_write(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    %done_writes_24 = taskflow.task @Task_12 will_reads(%done_writes_22 : memref<1x64x8x8xf32>) will_writes(%alloc_23 : memref<1x64x8x8xf32>) value_inputs(%cst_1, %cst_2 : f32, f32) [original_read_memrefs(%alloc_21 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_23 : memref<1x64x8x8xf32>)] {profile_info = {duration = 1 : i32}, task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 6 : i32, row = 0 : i32}], read_sram_locations = [{col = 1 : i32, row = 0 : i32}], write_sram_locations = [{col = 1 : i32, row = 0 : i32}]}} : (memref<1x64x8x8xf32>, memref<1x64x8x8xf32>, f32, f32) -> (memref<1x64x8x8xf32>) {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x64x8x8xf32>, %arg3: f32, %arg4: f32):
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c0 = arith.constant 0 : index
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      %c1 = arith.constant 1 : index
@@ -1299,13 +1299,13 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        memref.store %6, %arg2[%arg5, %arg6, %arg7, %arg8] : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:        taskflow.hyperblock.yield
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:      }) : (index, index, index, index) -> ()
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_write(%arg2 : memref<1x64x8x8xf32>)
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:      taskflow.yield done_writes(%arg2 : memref<1x64x8x8xf32>)
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:    }
-// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return %done_write_24 : memref<1x64x8x8xf32>
+// MAP-SPATIAL-TEMPORAL-1x2-NEXT:    return %done_writes_24 : memref<1x64x8x8xf32>
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:  }
 // MAP-SPATIAL-TEMPORAL-1x2-NEXT:}
 
-// RESOPT:          %done_read, %done_write:3 = taskflow.task @Task_1_Task_0_Task_2_utilfused_utilfused will_read(%arg0 : memref<1x64x8x8xf32>) will_write(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 5 : i32, profile_info = {duration = 3 : i32}, trip_count = 6400 : i32} : (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
+// RESOPT:          %done_reads, %done_writes:3 = taskflow.task @Task_1_Task_0_Task_2_utilfused_utilfused will_reads(%arg0 : memref<1x64x8x8xf32>) will_writes(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) value_inputs(%cst_2 : f32) [original_read_memrefs(%arg0 : memref<1x64x8x8xf32>), original_write_memrefs(%alloc_3, %alloc, %alloc_4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)] {cgra_count = 2 : i32, cgra_shape = "1x2", compiled_ii = 5 : i32, profile_info = {duration = 3 : i32}, trip_count = 6400 : i32} : (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>, f32) -> (memref<1x64x8x8xf32>, memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>) {
 // RESOPT-NEXT:     ^bb0(%arg1: memref<1x64x8x8xf32>, %arg2: memref<1x10x10x64xf32>, %arg3: memref<1x8x8x64xf32>, %arg4: memref<1x8x8x64xf32>, %arg5: f32):
 // RESOPT-NEXT:       %c64 = arith.constant 64 : index
 // RESOPT-NEXT:       %c10 = arith.constant 10 : index
@@ -1353,5 +1353,5 @@ module attributes {torch.debug_module_name = "SimpleResNetBlock"} {
 // RESOPT-NEXT:       %9 = taskflow.counter parent(%8 : index) from %c0_23 to %c8_22 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 1 : i32} : index
 // RESOPT-NEXT:       %10 = taskflow.counter parent(%9 : index) from %c0_23 to %c8_22 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "relay", counter_id = 2 : i32} : index
 // RESOPT-NEXT:       %11 = taskflow.counter parent(%10 : index) from %c0_23 to %c64_21 step %c1_24 attributes {counter_dynamism = "constant_bound", counter_hierarchy = "leaf", counter_id = 3 : i32} : index
-// RESOPT-NEXT:       taskflow.yield done_read(%arg1 : memref<1x64x8x8xf32>) done_write(%arg2, %arg3, %arg4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)
+// RESOPT-NEXT:       taskflow.yield done_reads(%arg1 : memref<1x64x8x8xf32>) done_writes(%arg2, %arg3, %arg4 : memref<1x10x10x64xf32>, memref<1x8x8x64xf32>, memref<1x8x8x64xf32>)
 // RESOPT-NEXT:     }

--- a/test/multi-cgra/taskflow/symbol-dynamic/conv1d/conv1d.mlir
+++ b/test/multi-cgra/taskflow/symbol-dynamic/conv1d/conv1d.mlir
@@ -36,7 +36,7 @@
 // AFFINE-NEXT:       }
 // AFFINE-NEXT:     }
 
-// TASKFLOW:          %done_write_0 = taskflow.task @Task_1 will_read(%arg0, %0, %done_write : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) will_write(%done_write : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
+// TASKFLOW:          %done_writes_0 = taskflow.task @Task_1 will_reads(%arg0, %0, %done_writes : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) will_writes(%done_writes : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg1: memref<1x1x?xf32>, %arg2: memref<16x1x3xf32>, %arg3: memref<1x16x?xf32>, %arg4: memref<1x16x?xf32>, %arg5: index):
 // TASKFLOW-NEXT:       affine.for %arg6 = 0 to 1 {
 // TASKFLOW-NEXT:         affine.for %arg7 = 0 to 16 {
@@ -54,10 +54,10 @@
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg4 : memref<1x16x?xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg4 : memref<1x16x?xf32>)
 // TASKFLOW-NEXT:     }
 
-// NEURA:      %done_write_0 = taskflow.task @Task_1 will_read(%arg0, %0, %done_write : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) will_write(%done_write : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
+// NEURA:      %done_writes_0 = taskflow.task @Task_1 will_reads(%arg0, %0, %done_writes : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) will_writes(%done_writes : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
 // NEURA-NEXT:     ^bb0(%arg1: memref<1x1x?xf32>, %arg2: memref<16x1x3xf32>, %arg3: memref<1x16x?xf32>, %arg4: memref<1x16x?xf32>, %arg5: index):
 // NEURA-NEXT:       %c3 = arith.constant 3 : index
 // NEURA-NEXT:       %c16 = arith.constant 16 : index
@@ -88,5 +88,5 @@
 // NEURA-NEXT:         memref.store %23, %arg8[%13, %14, %15] : memref<1x16x?xf32>
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield done_write(%arg4 : memref<1x16x?xf32>)
+// NEURA-NEXT:       taskflow.yield done_writes(%arg4 : memref<1x16x?xf32>)
 // NEURA-NEXT:     }

--- a/test/multi-cgra/taskflow/symbol-dynamic/conv1d/conv1d.mlir
+++ b/test/multi-cgra/taskflow/symbol-dynamic/conv1d/conv1d.mlir
@@ -36,7 +36,7 @@
 // AFFINE-NEXT:       }
 // AFFINE-NEXT:     }
 
-// TASKFLOW:          %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg0, %0, %dependency_write_out : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) dependency_write_in(%dependency_write_out : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
+// TASKFLOW:          %done_write_0 = taskflow.task @Task_1 will_read(%arg0, %0, %done_write : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) will_write(%done_write : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg1: memref<1x1x?xf32>, %arg2: memref<16x1x3xf32>, %arg3: memref<1x16x?xf32>, %arg4: memref<1x16x?xf32>, %arg5: index):
 // TASKFLOW-NEXT:       affine.for %arg6 = 0 to 1 {
 // TASKFLOW-NEXT:         affine.for %arg7 = 0 to 16 {
@@ -54,10 +54,10 @@
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg4 : memref<1x16x?xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg4 : memref<1x16x?xf32>)
 // TASKFLOW-NEXT:     }
 
-// NEURA:      %dependency_write_out_0 = taskflow.task @Task_1 dependency_read_in(%arg0, %0, %dependency_write_out : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) dependency_write_in(%dependency_write_out : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
+// NEURA:      %done_write_0 = taskflow.task @Task_1 will_read(%arg0, %0, %done_write : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>) will_write(%done_write : memref<1x16x?xf32>) value_inputs(%5 : index) [original_read_memrefs(%arg0, %0, %alloc : memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>), original_write_memrefs(%alloc : memref<1x16x?xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<1x1x?xf32>, memref<16x1x3xf32>, memref<1x16x?xf32>, memref<1x16x?xf32>, index) -> (memref<1x16x?xf32>) {
 // NEURA-NEXT:     ^bb0(%arg1: memref<1x1x?xf32>, %arg2: memref<16x1x3xf32>, %arg3: memref<1x16x?xf32>, %arg4: memref<1x16x?xf32>, %arg5: index):
 // NEURA-NEXT:       %c3 = arith.constant 3 : index
 // NEURA-NEXT:       %c16 = arith.constant 16 : index
@@ -88,5 +88,5 @@
 // NEURA-NEXT:         memref.store %23, %arg8[%13, %14, %15] : memref<1x16x?xf32>
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield writes(%arg4 : memref<1x16x?xf32>)
+// NEURA-NEXT:       taskflow.yield done_write(%arg4 : memref<1x16x?xf32>)
 // NEURA-NEXT:     }

--- a/test/multi-cgra/taskflow/symbol-dynamic/cross_attention/cross_attention.mlir
+++ b/test/multi-cgra/taskflow/symbol-dynamic/cross_attention/cross_attention.mlir
@@ -33,7 +33,7 @@
 // AFFINE-NEXT:       }
 // AFFINE-NEXT:     }
 
-// TASKFLOW:          %done_read_7, %done_write_8 = taskflow.task @Task_3 will_read(%arg0, %done_write, %done_write_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) will_write(%done_write_5 : memref<?x64xf32>) value_inputs(%dim_6 : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
+// TASKFLOW:          %done_reads_7, %done_writes_8 = taskflow.task @Task_3 will_reads(%arg0, %done_writes, %done_writes_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) will_writes(%done_writes_5 : memref<?x64xf32>) value_inputs(%dim_6 : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg2: memref<?x64xf32>, %arg3: memref<64x64xf32>, %arg4: memref<?x64xf32>, %arg5: memref<?x64xf32>, %arg6: index):
 // TASKFLOW-NEXT:       affine.for %arg7 = 0 to %arg6 {
 // TASKFLOW-NEXT:         affine.for %arg8 = 0 to 64 {
@@ -47,10 +47,10 @@
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_read(%arg3 : memref<64x64xf32>) done_write(%arg5 : memref<?x64xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_reads(%arg3 : memref<64x64xf32>) done_writes(%arg5 : memref<?x64xf32>)
 // TASKFLOW-NEXT:     }
 
-// NEURA:          %done_read_6, %done_write_7 = taskflow.task @Task_3 will_read(%arg0, %done_write, %done_write_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) will_write(%done_write_5 : memref<?x64xf32>) value_inputs(%dim : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
+// NEURA:          %done_reads_6, %done_writes_7 = taskflow.task @Task_3 will_reads(%arg0, %done_writes, %done_writes_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) will_writes(%done_writes_5 : memref<?x64xf32>) value_inputs(%dim : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
 // NEURA-NEXT:     ^bb0(%arg2: memref<?x64xf32>, %arg3: memref<64x64xf32>, %arg4: memref<?x64xf32>, %arg5: memref<?x64xf32>, %arg6: index):
 // NEURA-NEXT:       %c64 = arith.constant 64 : index
 // NEURA-NEXT:       %c0_45 = arith.constant 0 : index
@@ -74,5 +74,5 @@
 // NEURA-NEXT:         memref.store %14, %arg9[%7, %8] : memref<?x64xf32>
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield done_read(%arg3 : memref<64x64xf32>) done_write(%arg5 : memref<?x64xf32>)
+// NEURA-NEXT:       taskflow.yield done_reads(%arg3 : memref<64x64xf32>) done_writes(%arg5 : memref<?x64xf32>)
 // NEURA-NEXT:     }

--- a/test/multi-cgra/taskflow/symbol-dynamic/cross_attention/cross_attention.mlir
+++ b/test/multi-cgra/taskflow/symbol-dynamic/cross_attention/cross_attention.mlir
@@ -33,7 +33,7 @@
 // AFFINE-NEXT:       }
 // AFFINE-NEXT:     }
 
-// TASKFLOW:          %dependency_read_out_7, %dependency_write_out_8 = taskflow.task @Task_3 dependency_read_in(%arg0, %dependency_write_out, %dependency_write_out_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) dependency_write_in(%dependency_write_out_5 : memref<?x64xf32>) value_inputs(%dim_6 : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
+// TASKFLOW:          %done_read_7, %done_write_8 = taskflow.task @Task_3 will_read(%arg0, %done_write, %done_write_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) will_write(%done_write_5 : memref<?x64xf32>) value_inputs(%dim_6 : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg2: memref<?x64xf32>, %arg3: memref<64x64xf32>, %arg4: memref<?x64xf32>, %arg5: memref<?x64xf32>, %arg6: index):
 // TASKFLOW-NEXT:       affine.for %arg7 = 0 to %arg6 {
 // TASKFLOW-NEXT:         affine.for %arg8 = 0 to 64 {
@@ -47,10 +47,10 @@
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield reads(%arg3 : memref<64x64xf32>) writes(%arg5 : memref<?x64xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_read(%arg3 : memref<64x64xf32>) done_write(%arg5 : memref<?x64xf32>)
 // TASKFLOW-NEXT:     }
 
-// NEURA:          %dependency_read_out_6, %dependency_write_out_7 = taskflow.task @Task_3 dependency_read_in(%arg0, %dependency_write_out, %dependency_write_out_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) dependency_write_in(%dependency_write_out_5 : memref<?x64xf32>) value_inputs(%dim : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
+// NEURA:          %done_read_6, %done_write_7 = taskflow.task @Task_3 will_read(%arg0, %done_write, %done_write_5 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>) will_write(%done_write_5 : memref<?x64xf32>) value_inputs(%dim : index) [original_read_memrefs(%arg0, %alloc, %alloc_4 : memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>), original_write_memrefs(%alloc_4 : memref<?x64xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x64xf32>, memref<64x64xf32>, memref<?x64xf32>, memref<?x64xf32>, index) -> (memref<64x64xf32>, memref<?x64xf32>) {
 // NEURA-NEXT:     ^bb0(%arg2: memref<?x64xf32>, %arg3: memref<64x64xf32>, %arg4: memref<?x64xf32>, %arg5: memref<?x64xf32>, %arg6: index):
 // NEURA-NEXT:       %c64 = arith.constant 64 : index
 // NEURA-NEXT:       %c0_45 = arith.constant 0 : index
@@ -74,5 +74,5 @@
 // NEURA-NEXT:         memref.store %14, %arg9[%7, %8] : memref<?x64xf32>
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield reads(%arg3 : memref<64x64xf32>) writes(%arg5 : memref<?x64xf32>)
+// NEURA-NEXT:       taskflow.yield done_read(%arg3 : memref<64x64xf32>) done_write(%arg5 : memref<?x64xf32>)
 // NEURA-NEXT:     }

--- a/test/multi-cgra/taskflow/symbol-dynamic/gcn/gcn.mlir
+++ b/test/multi-cgra/taskflow/symbol-dynamic/gcn/gcn.mlir
@@ -35,7 +35,7 @@
 
 // TASKFLOW:          %dim_2 = memref.dim %arg1, %c0 : memref<?x?xf32>
 // TASKFLOW-NEXT:     %dim_3 = memref.dim %arg1, %c1 : memref<?x?xf32>
-// TASKFLOW-NEXT:     %done_write_4 = taskflow.task @Task_1 will_read(%arg1, %arg0, %done_write : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) will_write(%done_write : memref<?x8xf32>) value_inputs(%dim_2, %dim_3 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
+// TASKFLOW-NEXT:     %done_writes_4 = taskflow.task @Task_1 will_reads(%arg1, %arg0, %done_writes : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) will_writes(%done_writes : memref<?x8xf32>) value_inputs(%dim_2, %dim_3 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg2: memref<?x?xf32>, %arg3: memref<?x8xf32>, %arg4: memref<?x8xf32>, %arg5: memref<?x8xf32>, %arg6: index, %arg7: index):
 // TASKFLOW-NEXT:       affine.for %arg8 = 0 to %arg6 {
 // TASKFLOW-NEXT:         affine.for %arg9 = 0 to 8 {
@@ -49,10 +49,10 @@
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield done_write(%arg5 : memref<?x8xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_writes(%arg5 : memref<?x8xf32>)
 // TASKFLOW-NEXT:     }
 
-// NEURA:          %done_write_2 = taskflow.task @Task_1 will_read(%arg1, %arg0, %done_write : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) will_write(%done_write : memref<?x8xf32>) value_inputs(%dim, %dim_0 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
+// NEURA:          %done_writes_2 = taskflow.task @Task_1 will_reads(%arg1, %arg0, %done_writes : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) will_writes(%done_writes : memref<?x8xf32>) value_inputs(%dim, %dim_0 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
 // NEURA-NEXT:     ^bb0(%arg2: memref<?x?xf32>, %arg3: memref<?x8xf32>, %arg4: memref<?x8xf32>, %arg5: memref<?x8xf32>, %arg6: index, %arg7: index):
 // NEURA-NEXT:       %c8 = arith.constant 8 : index
 // NEURA-NEXT:       %c0_17 = arith.constant 0 : index
@@ -76,5 +76,5 @@
 // NEURA-NEXT:         memref.store %14, %arg10[%7, %8] : memref<?x8xf32>
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield done_write(%arg5 : memref<?x8xf32>)
+// NEURA-NEXT:       taskflow.yield done_writes(%arg5 : memref<?x8xf32>)
 // NEURA-NEXT:     }

--- a/test/multi-cgra/taskflow/symbol-dynamic/gcn/gcn.mlir
+++ b/test/multi-cgra/taskflow/symbol-dynamic/gcn/gcn.mlir
@@ -35,7 +35,7 @@
 
 // TASKFLOW:          %dim_2 = memref.dim %arg1, %c0 : memref<?x?xf32>
 // TASKFLOW-NEXT:     %dim_3 = memref.dim %arg1, %c1 : memref<?x?xf32>
-// TASKFLOW-NEXT:     %dependency_write_out_4 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg0, %dependency_write_out : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) dependency_write_in(%dependency_write_out : memref<?x8xf32>) value_inputs(%dim_2, %dim_3 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
+// TASKFLOW-NEXT:     %done_write_4 = taskflow.task @Task_1 will_read(%arg1, %arg0, %done_write : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) will_write(%done_write : memref<?x8xf32>) value_inputs(%dim_2, %dim_3 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
 // TASKFLOW-NEXT:     ^bb0(%arg2: memref<?x?xf32>, %arg3: memref<?x8xf32>, %arg4: memref<?x8xf32>, %arg5: memref<?x8xf32>, %arg6: index, %arg7: index):
 // TASKFLOW-NEXT:       affine.for %arg8 = 0 to %arg6 {
 // TASKFLOW-NEXT:         affine.for %arg9 = 0 to 8 {
@@ -49,10 +49,10 @@
 // TASKFLOW-NEXT:           }
 // TASKFLOW-NEXT:         }
 // TASKFLOW-NEXT:       }
-// TASKFLOW-NEXT:       taskflow.yield writes(%arg5 : memref<?x8xf32>)
+// TASKFLOW-NEXT:       taskflow.yield done_write(%arg5 : memref<?x8xf32>)
 // TASKFLOW-NEXT:     }
 
-// NEURA:          %dependency_write_out_2 = taskflow.task @Task_1 dependency_read_in(%arg1, %arg0, %dependency_write_out : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) dependency_write_in(%dependency_write_out : memref<?x8xf32>) value_inputs(%dim, %dim_0 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
+// NEURA:          %done_write_2 = taskflow.task @Task_1 will_read(%arg1, %arg0, %done_write : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>) will_write(%done_write : memref<?x8xf32>) value_inputs(%dim, %dim_0 : index, index) [original_read_memrefs(%arg1, %arg0, %alloc : memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>), original_write_memrefs(%alloc : memref<?x8xf32>)] {dlp_replicable = true, runtime_managable = true} : (memref<?x?xf32>, memref<?x8xf32>, memref<?x8xf32>, memref<?x8xf32>, index, index) -> (memref<?x8xf32>) {
 // NEURA-NEXT:     ^bb0(%arg2: memref<?x?xf32>, %arg3: memref<?x8xf32>, %arg4: memref<?x8xf32>, %arg5: memref<?x8xf32>, %arg6: index, %arg7: index):
 // NEURA-NEXT:       %c8 = arith.constant 8 : index
 // NEURA-NEXT:       %c0_17 = arith.constant 0 : index
@@ -76,5 +76,5 @@
 // NEURA-NEXT:         memref.store %14, %arg10[%7, %8] : memref<?x8xf32>
 // NEURA-NEXT:         neura.yield
 // NEURA-NEXT:       }
-// NEURA-NEXT:       taskflow.yield writes(%arg5 : memref<?x8xf32>)
+// NEURA-NEXT:       taskflow.yield done_write(%arg5 : memref<?x8xf32>)
 // NEURA-NEXT:     }


### PR DESCRIPTION
Rename Taskflow memory dependency states from `dependency_*_in/out` to `will_read`, `will_write`, `done_read`, and `done_write` across op assembly, accessors, implementation, and tests.