### PR TITLE
Add task pipeline interval analyzer

### DIFF
--- a/include/TaskflowDialect/Orchestration/orchestration_utils.h
+++ b/include/TaskflowDialect/Orchestration/orchestration_utils.h
@@ -3,12 +3,15 @@
 #ifndef TASKFLOW_ORCHESTRATION_UTILS_H
 #define TASKFLOW_ORCHESTRATION_UTILS_H
 
+#include "TaskflowDialect/TaskflowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -110,6 +113,120 @@ class TaskMemoryGraph;
 // Caller-provided task priority; higher values are scheduled earlier.
 using TaskPriorityMap = llvm::DenseMap<Operation *, int>;
 
+// Concrete schedule result for one task after TaskScheduler placement.
+struct TaskScheduleResult {
+  // One CGRA cell occupied by this task.
+  struct CgraOccupancy {
+    int row = 0;
+    int col = 0;
+    int start_time = 0;
+    int duration = 1;
+    int context_id = 0;
+  };
+
+  TaskflowTaskOp task;
+  int start_time = 0;
+  int duration = 1;
+  int end_time = 1;
+  llvm::SmallVector<CgraOccupancy> cgra_occupancies;
+  llvm::SmallVector<TaskflowTaskOp> predecessor_tasks;
+  llvm::SmallVector<TaskflowTaskOp> successor_tasks;
+};
+
+// Pipeline interval analysis result for a concrete task schedule.
+struct TaskPipelineIntervalResult {
+  int pipeline_interval = 0;
+  TaskflowTaskOp bottleneck_task;
+  llvm::SmallVector<TaskflowTaskOp> critical_path;
+};
+
+// Builds a task-level schedule analysis graph and derives the steady-state
+// pipeline interval for the concrete schedule produced by TaskScheduler.
+//
+// The graph nodes are the scheduled tasks for one input instance. The graph
+// contains two kinds of execution-order edges:
+//
+//   1. Data-dependence edges.
+//      If T1 consumes a value/token produced by T0, add T0 -> T1 with latency
+//      latency(T0). This says T1 cannot execute until T0 has completed.
+//
+//   2. CGRA execution-order edges.
+//      If a physical CGRA runs T0 before T2 for the same input instance, add
+//      T0 -> T2 with latency latency(T0). This says T2 cannot use that CGRA
+//      until T0 releases its context slot.
+//
+// The graph gives ordering within one input instance. To compute steady-state
+// throughput, each CGRA also defines a pipeline cycle: the last task using
+// that CGRA for this input instance must finish before the first task using
+// that same CGRA for the next input instance can start.
+//
+//      first_task(this input) -> ... -> last_task(this input)
+//      last_task(this input)  -> first_task(next input)
+//
+// The interval required by that CGRA is the latency of the longest path from
+// first_task to last_task in the analysis graph, plus latency(last_task) for
+// the transition to the next input instance. The overall pipeline interval is
+// the maximum interval over all CGRA pipeline cycles.
+//
+// Example:
+//   Data dependence: T0 -> T1 -> T2
+//   Placement:       T0 on CGRA0, T1 on CGRA1, T2 on CGRA0
+//
+// The analysis graph contains data-dependence edges T0 -> T1 and T1 -> T2.
+// Since T0 and T2 reuse CGRA0 in order, it also contains a CGRA
+// execution-order edge T0 -> T2. CGRA0 then defines the pipeline cycle
+// T0(this input) -> T1 -> T2 -> T0(next input), requiring
+// latency(T0)+latency(T1)+latency(T2).
+class TaskPipelineIntervalAnalyzer {
+public:
+  explicit TaskPipelineIntervalAnalyzer(
+      llvm::ArrayRef<TaskScheduleResult> schedule_result);
+
+  TaskPipelineIntervalResult analyze();
+
+private:
+  // Edge in the analysis graph that says `task` must execute before
+  // `next_task`. It is created either by a data dependence or by sequential
+  // reuse of the same CGRA context.
+  struct ExecutionOrderEdge {
+    int next_task = -1;
+    int latency = 0;
+  };
+
+  // Pipeline cycle induced by one physical CGRA. `last_task` is the final task
+  // using that CGRA for this input instance, and `first_task` is the first task
+  // using that same CGRA for the next input instance.
+  struct CgraPipelineCycle {
+    int last_task = -1;
+    int first_task = -1;
+    int latency = 0;
+  };
+
+  // Longest execution-order path found between two task nodes.
+  struct LongestExecutionPath {
+    bool found = false;
+    int total_latency = 0;
+    llvm::SmallVector<int> path;
+  };
+
+  int getTaskDuration(int task_idx) const;
+  int64_t
+  encodeCgraLocation(const TaskScheduleResult::CgraOccupancy &occupancy) const;
+  void addExecutionOrderEdge(int task, int next_task);
+  void buildTaskIndex();
+  void buildDataDependenceEdges();
+  void buildCgraExecutionOrderEdgesAndPipelineCycles();
+  LongestExecutionPath
+  findLongestPathToTarget(int current, int target,
+                          llvm::DenseSet<int> &visiting) const;
+  TaskPipelineIntervalResult computeLongestPipelineCycle() const;
+
+  llvm::ArrayRef<TaskScheduleResult> schedule_result_;
+  llvm::DenseMap<Operation *, int> task_to_index_;
+  llvm::SmallVector<llvm::SmallVector<ExecutionOrderEdge>> task_graph_;
+  llvm::SmallVector<CgraPipelineCycle> cgra_pipeline_cycles_;
+};
+
 // Reusable one-shot scheduler/placer for Taskflow task graphs.
 //
 // Builds the task-memory graph, schedules tasks using the provided priority,
@@ -124,7 +241,15 @@ public:
   // task priority map.
   bool schedule(func::FuncOp func, const TaskPriorityMap &priority);
 
+  // Returns the concrete task schedule produced by schedule().
+  llvm::ArrayRef<TaskScheduleResult> getScheduleResult() const {
+    return schedule_result_;
+  }
+
 private:
+  // Records concrete schedule facts from the internal task placement.
+  void recordScheduleResult(const TaskMemoryGraph &graph);
+
   // Returns true if a CGRA grid coordinate is inside the configured grid.
   bool posInBounds(const CgraPosition &pos) const;
 
@@ -168,6 +293,7 @@ private:
   int grid_cols_;
   SchedulingMode mode_;
   int total_task_count_ = 0;
+  llvm::SmallVector<TaskScheduleResult> schedule_result_;
   std::vector<std::vector<llvm::SmallVector<std::pair<int, int>, 4>>>
       cgra_occupancy_;
 };

--- a/include/TaskflowDialect/TaskflowPasses.h
+++ b/include/TaskflowDialect/TaskflowPasses.h
@@ -25,6 +25,7 @@ void registerLinalgToAffineConversionPassPipeline();
 std::unique_ptr<mlir::Pass> createConstructHyperblockFromTaskPass();
 std::unique_ptr<mlir::Pass> createClassifyTaskAndCounterPass();
 std::unique_ptr<mlir::Pass> createOrchestrateTasksOnAcceleratorsPass();
+std::unique_ptr<mlir::Pass> createAnalyzeTaskPipelineIntervalPass();
 std::unique_ptr<mlir::Pass> createFuseTaskPass();
 
 //=========================================================//

--- a/include/TaskflowDialect/TaskflowPasses.td
+++ b/include/TaskflowDialect/TaskflowPasses.td
@@ -127,6 +127,22 @@ def OrchestrateTasksOnAccelerators : Pass<"orchestrate-tasks-on-accelerators", "
   let constructor = "taskflow::createOrchestrateTasksOnAcceleratorsPass()";
 }
 
+def AnalyzeTaskPipelineInterval
+    : Pass<"analyze-task-pipeline-interval", "func::FuncOp"> {
+  let summary =
+      "Analyzes the pipeline interval of already-profiled and scheduled tasks";
+  let description = [{
+    Reads taskflow.task operations that already contain profile_info.duration
+    and task_orchestration_info.cgra_positions. The pass reconstructs the
+    concrete task schedule from task dependences and per-CGRA context order,
+    invokes TaskPipelineIntervalAnalyzer, and emits task_pipeline_interval_info
+    on the parent func.func.
+  }];
+  let constructor = "taskflow::createAnalyzeTaskPipelineIntervalPass()";
+  let dependentDialects = ["mlir::func::FuncDialect",
+                           "mlir::taskflow::TaskflowDialect"];
+}
+
 def FuseTask : Pass<"fuse-task", "func::FuncOp"> {
   let summary =
       "Fuses Taskflow tasks using producer-consumer and sibling strategies";

--- a/lib/TaskflowDialect/Orchestration/orchestration_utils.cpp
+++ b/lib/TaskflowDialect/Orchestration/orchestration_utils.cpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <climits>
 #include <cmath>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -463,6 +464,165 @@ private:
   }
 };
 
+// TaskPipelineIntervalAnalyzer
+
+TaskPipelineIntervalAnalyzer::TaskPipelineIntervalAnalyzer(
+    ArrayRef<TaskScheduleResult> schedule_result)
+    : schedule_result_(schedule_result) {}
+
+TaskPipelineIntervalResult TaskPipelineIntervalAnalyzer::analyze() {
+  TaskPipelineIntervalResult result;
+  if (schedule_result_.empty()) {
+    return result;
+  }
+
+  buildTaskIndex();
+  task_graph_.resize(schedule_result_.size());
+  buildDataDependenceEdges();
+  buildCgraExecutionOrderEdgesAndPipelineCycles();
+  return computeLongestPipelineCycle();
+}
+
+int TaskPipelineIntervalAnalyzer::getTaskDuration(int task_idx) const {
+  return std::max(1, schedule_result_[task_idx].duration);
+}
+
+int64_t TaskPipelineIntervalAnalyzer::encodeCgraLocation(
+    const TaskScheduleResult::CgraOccupancy &occupancy) const {
+  return (static_cast<int64_t>(occupancy.row) << 32) |
+         static_cast<uint32_t>(occupancy.col);
+}
+
+void TaskPipelineIntervalAnalyzer::addExecutionOrderEdge(int task,
+                                                         int next_task) {
+  if (task < 0 || next_task < 0 || task == next_task) {
+    return;
+  }
+  task_graph_[task].push_back({next_task, getTaskDuration(task)});
+}
+
+void TaskPipelineIntervalAnalyzer::buildTaskIndex() {
+  for (auto [idx, task_result] : llvm::enumerate(schedule_result_)) {
+    TaskflowTaskOp task = task_result.task;
+    task_to_index_[task.getOperation()] = static_cast<int>(idx);
+  }
+}
+
+void TaskPipelineIntervalAnalyzer::buildDataDependenceEdges() {
+  for (auto [task_idx, task_result] : llvm::enumerate(schedule_result_)) {
+    for (TaskflowTaskOp pred : task_result.predecessor_tasks) {
+      auto pred_it = task_to_index_.find(pred.getOperation());
+      if (pred_it == task_to_index_.end()) {
+        continue;
+      }
+      addExecutionOrderEdge(pred_it->second, static_cast<int>(task_idx));
+    }
+  }
+}
+
+void TaskPipelineIntervalAnalyzer::
+    buildCgraExecutionOrderEdgesAndPipelineCycles() {
+  DenseMap<int64_t, SmallVector<int>> cgra_location_to_tasks;
+  for (auto [idx, task_result] : llvm::enumerate(schedule_result_)) {
+    for (const TaskScheduleResult::CgraOccupancy &occupancy :
+         task_result.cgra_occupancies) {
+      cgra_location_to_tasks[encodeCgraLocation(occupancy)].push_back(
+          static_cast<int>(idx));
+    }
+  }
+
+  for (auto &entry : cgra_location_to_tasks) {
+    SmallVector<int> &tasks = entry.second;
+    llvm::sort(tasks, [&](int lhs, int rhs) {
+      const TaskScheduleResult &lhs_result = schedule_result_[lhs];
+      const TaskScheduleResult &rhs_result = schedule_result_[rhs];
+      if (lhs_result.start_time != rhs_result.start_time) {
+        return lhs_result.start_time < rhs_result.start_time;
+      }
+      return lhs < rhs;
+    });
+
+    for (size_t i = 1; i < tasks.size(); ++i) {
+      addExecutionOrderEdge(tasks[i - 1], tasks[i]);
+    }
+
+    int first = tasks.front();
+    int last = tasks.back();
+    cgra_pipeline_cycles_.push_back({last, first, getTaskDuration(last)});
+  }
+}
+
+TaskPipelineIntervalAnalyzer::LongestExecutionPath
+TaskPipelineIntervalAnalyzer::findLongestPathToTarget(
+    int current, int target, DenseSet<int> &visiting) const {
+  if (current == target) {
+    LongestExecutionPath result;
+    result.found = true;
+    result.path.push_back(current);
+    return result;
+  }
+
+  if (visiting.contains(current)) {
+    return LongestExecutionPath();
+  }
+
+  visiting.insert(current);
+  LongestExecutionPath best;
+  for (const ExecutionOrderEdge &edge : task_graph_[current]) {
+    LongestExecutionPath suffix =
+        findLongestPathToTarget(edge.next_task, target, visiting);
+    if (!suffix.found) {
+      continue;
+    }
+
+    int total_latency = edge.latency + suffix.total_latency;
+    if (!best.found || total_latency > best.total_latency) {
+      best.found = true;
+      best.total_latency = total_latency;
+      best.path.clear();
+      best.path.push_back(current);
+      best.path.append(suffix.path.begin(), suffix.path.end());
+    }
+  }
+  visiting.erase(current);
+  return best;
+}
+
+TaskPipelineIntervalResult
+TaskPipelineIntervalAnalyzer::computeLongestPipelineCycle() const {
+  TaskPipelineIntervalResult result;
+  for (const CgraPipelineCycle &pipeline_cycle : cgra_pipeline_cycles_) {
+    DenseSet<int> visiting;
+    LongestExecutionPath path = findLongestPathToTarget(
+        pipeline_cycle.first_task, pipeline_cycle.last_task, visiting);
+    if (!path.found) {
+      continue;
+    }
+
+    int interval = path.total_latency + pipeline_cycle.latency;
+    if (interval <= result.pipeline_interval) {
+      continue;
+    }
+
+    result.pipeline_interval = interval;
+    result.critical_path.clear();
+
+    int bottleneck_idx = pipeline_cycle.last_task;
+    int bottleneck_duration = getTaskDuration(bottleneck_idx);
+    for (int idx : path.path) {
+      const TaskScheduleResult &task_result = schedule_result_[idx];
+      result.critical_path.push_back(task_result.task);
+      int duration = getTaskDuration(idx);
+      if (duration > bottleneck_duration) {
+        bottleneck_idx = idx;
+        bottleneck_duration = duration;
+      }
+    }
+    result.bottleneck_task = schedule_result_[bottleneck_idx].task;
+  }
+  return result;
+}
+
 // TaskScheduler
 // Orchestrates a task-memory graph onto a 2D multi-CGRA grid using the
 // priority provided by the caller.
@@ -487,6 +647,8 @@ TaskScheduler::TaskScheduler(int grid_rows, int grid_cols, SchedulingMode mode)
 // Schedules all tasks and performs iterative SRAM assignment for `func`.
 bool TaskScheduler::schedule(func::FuncOp func,
                              const TaskPriorityMap &priority) {
+  schedule_result_.clear();
+
   SmallVector<TaskflowTaskOp> tasks;
   func.walk([&](TaskflowTaskOp task) { tasks.push_back(task); });
 
@@ -608,6 +770,8 @@ bool TaskScheduler::schedule(func::FuncOp func,
     }
   }
 
+  recordScheduleResult(graph);
+
   // Write output attributes.
   OpBuilder builder(func.getContext());
   for (auto &task_node : graph.task_nodes) {
@@ -697,6 +861,39 @@ bool TaskScheduler::schedule(func::FuncOp func,
     task_node->op->removeAttr("cgra_shape");
   }
   return true;
+}
+
+void TaskScheduler::recordScheduleResult(const TaskMemoryGraph &graph) {
+  schedule_result_.clear();
+  for (const auto &task_node : graph.task_nodes) {
+    if (task_node->placement.empty()) {
+      continue;
+    }
+
+    TaskScheduleResult task_result;
+    task_result.task = task_node->op;
+    task_result.start_time = task_node->placement.front().start_time;
+    task_result.duration = task_node->placement.front().duration;
+    task_result.end_time = task_result.start_time + task_result.duration;
+
+    for (const CgraPosition &pos : task_node->placement) {
+      task_result.start_time = std::min(task_result.start_time, pos.start_time);
+      task_result.end_time =
+          std::max(task_result.end_time, pos.start_time + pos.duration);
+      task_result.cgra_occupancies.push_back(
+          {pos.row, pos.col, pos.start_time, pos.duration, pos.context_id});
+    }
+    task_result.duration = task_result.end_time - task_result.start_time;
+
+    for (TaskNode *pred : task_node->ssa_operands) {
+      task_result.predecessor_tasks.push_back(pred->op);
+    }
+    for (TaskNode *succ : task_node->ssa_users) {
+      task_result.successor_tasks.push_back(succ->op);
+    }
+
+    schedule_result_.push_back(std::move(task_result));
+  }
 }
 
 bool TaskScheduler::posInBounds(const CgraPosition &pos) const {

--- a/lib/TaskflowDialect/Transforms/AnalyzeTaskPipelineIntervalPass.cpp
+++ b/lib/TaskflowDialect/Transforms/AnalyzeTaskPipelineIntervalPass.cpp
@@ -1,0 +1,353 @@
+// Analyze scheduled Taskflow pipeline interval.
+
+#include "TaskflowDialect/Orchestration/orchestration_utils.h"
+#include "TaskflowDialect/TaskflowOps.h"
+#include "TaskflowDialect/TaskflowPasses.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+
+using namespace mlir;
+using namespace mlir::taskflow;
+
+namespace {
+
+static int getRequiredTaskDuration(TaskflowTaskOp task) {
+  auto profile_info = task->getAttrOfType<DictionaryAttr>("profile_info");
+  if (!profile_info) {
+    task.emitOpError() << "requires profile_info.duration";
+    return -1;
+  }
+
+  auto duration = dyn_cast_or_null<IntegerAttr>(profile_info.get("duration"));
+  if (!duration) {
+    task.emitOpError() << "requires profile_info.duration";
+    return -1;
+  }
+
+  return std::max(1, static_cast<int>(duration.getInt()));
+}
+
+static std::optional<TaskScheduleResult::CgraOccupancy>
+parseCgraOccupancy(TaskflowTaskOp task, Attribute attr) {
+  auto coord = dyn_cast<DictionaryAttr>(attr);
+  if (!coord) {
+    task.emitOpError() << "requires dictionary entries in "
+                          "task_orchestration_info.cgra_positions";
+    return std::nullopt;
+  }
+
+  auto row = dyn_cast_or_null<IntegerAttr>(coord.get("row"));
+  auto col = dyn_cast_or_null<IntegerAttr>(coord.get("col"));
+  auto context_id = dyn_cast_or_null<IntegerAttr>(coord.get("context_id"));
+  if (!row || !col || !context_id) {
+    task.emitOpError() << "requires row, col, and context_id in each "
+                          "task_orchestration_info.cgra_positions entry";
+    return std::nullopt;
+  }
+
+  TaskScheduleResult::CgraOccupancy occupancy;
+  occupancy.row = static_cast<int>(row.getInt());
+  occupancy.col = static_cast<int>(col.getInt());
+  occupancy.context_id = static_cast<int>(context_id.getInt());
+  return occupancy;
+}
+
+static LogicalResult readTaskCgraOccupancies(
+    TaskflowTaskOp task,
+    SmallVectorImpl<TaskScheduleResult::CgraOccupancy> &occupancies) {
+  auto orchestration_info =
+      task->getAttrOfType<DictionaryAttr>("task_orchestration_info");
+  if (!orchestration_info) {
+    return task.emitOpError() << "requires task_orchestration_info";
+  }
+
+  auto cgra_positions =
+      dyn_cast_or_null<ArrayAttr>(orchestration_info.get("cgra_positions"));
+  if (!cgra_positions || cgra_positions.empty()) {
+    return task.emitOpError()
+           << "requires non-empty task_orchestration_info.cgra_positions";
+  }
+
+  for (Attribute attr : cgra_positions) {
+    std::optional<TaskScheduleResult::CgraOccupancy> occupancy =
+        parseCgraOccupancy(task, attr);
+    if (!occupancy) {
+      return failure();
+    }
+    occupancies.push_back(*occupancy);
+  }
+  return success();
+}
+
+static int64_t
+encodeCgraLocation(const TaskScheduleResult::CgraOccupancy &occupancy) {
+  return (static_cast<int64_t>(occupancy.row) << 32) |
+         static_cast<uint32_t>(occupancy.col);
+}
+
+class TaskScheduleResultParser {
+public:
+  explicit TaskScheduleResultParser(func::FuncOp func) : func_(func) {}
+
+  FailureOr<SmallVector<TaskScheduleResult>> parse() {
+    collectTasks();
+    if (failed(buildScheduleResults())) {
+      return failure();
+    }
+    buildTaskDependences();
+    buildCgraExecutionOrderDependences();
+    if (failed(computeStartTimes())) {
+      return failure();
+    }
+    updateScheduleTimes();
+    return schedule_result_;
+  }
+
+private:
+  void collectTasks() {
+    func_.walk([&](TaskflowTaskOp task) {
+      task_to_index_[task.getOperation()] = tasks_.size();
+      tasks_.push_back(task);
+    });
+  }
+
+  LogicalResult buildScheduleResults() {
+    for (TaskflowTaskOp task : tasks_) {
+      int duration = getRequiredTaskDuration(task);
+      if (duration < 0) {
+        return failure();
+      }
+
+      TaskScheduleResult task_result;
+      task_result.task = task;
+      task_result.duration = duration;
+      task_result.end_time = duration;
+      if (failed(readTaskCgraOccupancies(task, task_result.cgra_occupancies))) {
+        return failure();
+      }
+
+      for (TaskScheduleResult::CgraOccupancy &occupancy :
+           task_result.cgra_occupancies) {
+        occupancy.duration = duration;
+      }
+
+      schedule_result_.push_back(std::move(task_result));
+    }
+    return success();
+  }
+
+  void addExecutionOrderDependence(int task, int next_task) {
+    if (task < 0 || next_task < 0 || task == next_task) {
+      return;
+    }
+
+    int64_t edge_key =
+        (static_cast<int64_t>(task) << 32) | static_cast<uint32_t>(next_task);
+    if (!execution_order_edge_keys_.insert(edge_key).second) {
+      return;
+    }
+
+    successors_[task].push_back(next_task);
+    ++predecessor_count_[next_task];
+  }
+
+  void buildTaskDependences() {
+    successors_.resize(tasks_.size());
+    predecessor_count_.assign(tasks_.size(), 0);
+    start_times_.assign(tasks_.size(), 0);
+
+    for (auto [task_idx, task] : llvm::enumerate(tasks_)) {
+      for (Value operand : task->getOperands()) {
+        auto producer = operand.getDefiningOp<TaskflowTaskOp>();
+        if (!producer) {
+          continue;
+        }
+
+        auto producer_it = task_to_index_.find(producer.getOperation());
+        if (producer_it == task_to_index_.end()) {
+          continue;
+        }
+
+        int producer_idx = producer_it->second;
+        addExecutionOrderDependence(producer_idx, static_cast<int>(task_idx));
+        schedule_result_[task_idx].predecessor_tasks.push_back(producer);
+        schedule_result_[producer_idx].successor_tasks.push_back(task);
+      }
+    }
+  }
+
+  void buildCgraExecutionOrderDependences() {
+    DenseMap<int64_t, SmallVector<int>> cgra_location_to_tasks;
+    for (auto [task_idx, task_result] : llvm::enumerate(schedule_result_)) {
+      for (const TaskScheduleResult::CgraOccupancy &occupancy :
+           task_result.cgra_occupancies) {
+        cgra_location_to_tasks[encodeCgraLocation(occupancy)].push_back(
+            static_cast<int>(task_idx));
+      }
+    }
+
+    for (auto &entry : cgra_location_to_tasks) {
+      SmallVector<int> &tasks = entry.second;
+      llvm::sort(tasks, [&](int lhs, int rhs) {
+        int lhs_context = getTaskContextOnCgra(lhs, entry.first);
+        int rhs_context = getTaskContextOnCgra(rhs, entry.first);
+        if (lhs_context != rhs_context) {
+          return lhs_context < rhs_context;
+        }
+        return lhs < rhs;
+      });
+
+      for (size_t i = 1; i < tasks.size(); ++i) {
+        addExecutionOrderDependence(tasks[i - 1], tasks[i]);
+      }
+    }
+  }
+
+  int getTaskContextOnCgra(int task_idx, int64_t cgra_location) const {
+    for (const TaskScheduleResult::CgraOccupancy &occupancy :
+         schedule_result_[task_idx].cgra_occupancies) {
+      if (encodeCgraLocation(occupancy) == cgra_location) {
+        return occupancy.context_id;
+      }
+    }
+    return 0;
+  }
+
+  LogicalResult computeStartTimes() {
+    SmallVector<int> ready_tasks;
+    for (auto [task_idx, pred_count] : llvm::enumerate(predecessor_count_)) {
+      if (pred_count == 0) {
+        ready_tasks.push_back(static_cast<int>(task_idx));
+      }
+    }
+
+    size_t processed_tasks = 0;
+    while (!ready_tasks.empty()) {
+      int task = ready_tasks.pop_back_val();
+      ++processed_tasks;
+
+      for (int next_task : successors_[task]) {
+        int next_start = start_times_[task] + schedule_result_[task].duration;
+        start_times_[next_task] = std::max(start_times_[next_task], next_start);
+
+        --predecessor_count_[next_task];
+        if (predecessor_count_[next_task] == 0) {
+          ready_tasks.push_back(next_task);
+        }
+      }
+    }
+
+    if (processed_tasks != tasks_.size()) {
+      return func_.emitError()
+             << "cannot analyze task pipeline interval because task "
+                "dependences and CGRA context order form a cycle";
+    }
+    return success();
+  }
+
+  void updateScheduleTimes() {
+    for (auto [task_idx, task_result] : llvm::enumerate(schedule_result_)) {
+      int start_time = start_times_[task_idx];
+      task_result.start_time = start_time;
+      task_result.end_time = start_time + task_result.duration;
+      for (TaskScheduleResult::CgraOccupancy &occupancy :
+           task_result.cgra_occupancies) {
+        occupancy.start_time = start_time;
+        occupancy.duration = task_result.duration;
+      }
+    }
+  }
+
+  func::FuncOp func_;
+  SmallVector<TaskflowTaskOp> tasks_;
+  DenseMap<Operation *, int> task_to_index_;
+  DenseSet<int64_t> execution_order_edge_keys_;
+  SmallVector<SmallVector<int>> successors_;
+  SmallVector<int> predecessor_count_;
+  SmallVector<int> start_times_;
+  SmallVector<TaskScheduleResult> schedule_result_;
+};
+
+static ArrayAttr buildTaskNameArray(MLIRContext *context,
+                                    ArrayRef<TaskflowTaskOp> tasks) {
+  SmallVector<Attribute> task_names;
+  for (TaskflowTaskOp task : tasks) {
+    task_names.push_back(StringAttr::get(context, task.getTaskName()));
+  }
+  return ArrayAttr::get(context, task_names);
+}
+
+static void emitPipelineIntervalInfo(func::FuncOp func,
+                                     const TaskPipelineIntervalResult &result) {
+  MLIRContext *context = func.getContext();
+  OpBuilder builder(context);
+
+  SmallVector<NamedAttribute> attrs;
+  attrs.push_back(builder.getNamedAttr(
+      "pipeline_interval",
+      builder.getI32IntegerAttr(result.pipeline_interval)));
+
+  StringRef bottleneck_task_name = "";
+  if (result.bottleneck_task) {
+    TaskflowTaskOp bottleneck_task = result.bottleneck_task;
+    bottleneck_task_name = bottleneck_task.getTaskName();
+  }
+  attrs.push_back(builder.getNamedAttr(
+      "bottleneck_task", builder.getStringAttr(bottleneck_task_name)));
+  attrs.push_back(builder.getNamedAttr(
+      "critical_path", buildTaskNameArray(context, result.critical_path)));
+
+  func->setAttr("task_pipeline_interval_info",
+                DictionaryAttr::get(context, attrs));
+}
+
+struct AnalyzeTaskPipelineIntervalPass
+    : public PassWrapper<AnalyzeTaskPipelineIntervalPass,
+                         OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(AnalyzeTaskPipelineIntervalPass)
+
+  StringRef getArgument() const override {
+    return "analyze-task-pipeline-interval";
+  }
+
+  StringRef getDescription() const override {
+    return "Analyzes pipeline interval for profiled and scheduled Taskflow "
+           "tasks";
+  }
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    TaskScheduleResultParser parser(func);
+    FailureOr<SmallVector<TaskScheduleResult>> schedule_result = parser.parse();
+    if (failed(schedule_result)) {
+      signalPassFailure();
+      return;
+    }
+
+    TaskPipelineIntervalResult result =
+        TaskPipelineIntervalAnalyzer(*schedule_result).analyze();
+    emitPipelineIntervalInfo(func, result);
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace taskflow {
+
+std::unique_ptr<Pass> createAnalyzeTaskPipelineIntervalPass() {
+  return std::make_unique<AnalyzeTaskPipelineIntervalPass>();
+}
+
+} // namespace taskflow
+} // namespace mlir

--- a/lib/TaskflowDialect/Transforms/CMakeLists.txt
+++ b/lib/TaskflowDialect/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_mlir_library(MLIRTaskflowTransforms
+    AnalyzeTaskPipelineIntervalPass.cpp
     OrchestrateTasksOnAcceleratorsPass.cpp
     ConstructHyperblockFromTaskPass.cpp
     ClassifyTaskAndCounterPass.cpp

--- a/test/multi-cgra/taskflow/pipeline-interval/chain_reuse_cgra0.mlir
+++ b/test/multi-cgra/taskflow/pipeline-interval/chain_reuse_cgra0.mlir
@@ -1,0 +1,61 @@
+// Hand-written schedule-analysis case for TaskPipelineIntervalAnalyzer.
+//
+// Data dependence: T0 -> T1 -> T2
+// CGRA0: T0, then T2
+// CGRA1: T1
+//
+// Expected analysis graph:
+//   Data-dependence edges:     T0 -> T1, T1 -> T2
+//   CGRA execution-order edge: T0 -> T2
+//
+// Expected pipeline cycles:
+//   CGRA0: T0(this input) -> T1 -> T2 -> T0(next input)
+//          interval = 2 + 3 + 5 = 10
+//   CGRA1: T1(this input) -> T1(next input)
+//          interval = 3
+//
+// Expected pipeline interval: 10
+
+
+// RUN: mlir-neura-opt %s --analyze-task-pipeline-interval | FileCheck %s
+//
+// CHECK-LABEL: func.func @chain_reuse_cgra0
+// CHECK-SAME: task_pipeline_interval_info = {bottleneck_task = "Task_2",
+// CHECK-SAME: critical_path = ["Task_0", "Task_1", "Task_2"]
+// CHECK-SAME: pipeline_interval = 10 : i32
+
+module {
+  func.func @chain_reuse_cgra0(%seed: i32) -> i32 {
+    %t0 = taskflow.task @Task_0 value_inputs(%seed : i32)
+        {profile_info = {duration = 2 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    %t1 = taskflow.task @Task_1 value_inputs(%t0 : i32)
+        {profile_info = {duration = 3 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    %t2 = taskflow.task @Task_2 value_inputs(%t1 : i32)
+        {profile_info = {duration = 5 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    return %t2 : i32
+  }
+}

--- a/test/multi-cgra/taskflow/pipeline-interval/chain_reuse_cgra1.mlir
+++ b/test/multi-cgra/taskflow/pipeline-interval/chain_reuse_cgra1.mlir
@@ -1,0 +1,60 @@
+// Hand-written schedule-analysis case for TaskPipelineIntervalAnalyzer.
+//
+// Data dependence: T0 -> T1 -> T2
+// CGRA0: T0
+// CGRA1: T1, then T2
+//
+// Expected analysis graph:
+//   Data-dependence edges:     T0 -> T1, T1 -> T2
+//   CGRA execution-order edge: T1 -> T2
+//
+// Expected pipeline cycles:
+//   CGRA0: T0(this input) -> T0(next input)
+//          interval = 2
+//   CGRA1: T1(this input) -> T2 -> T1(next input)
+//          interval = 3 + 5 = 8
+//
+// Expected pipeline interval: 8
+
+// RUN: mlir-neura-opt %s --analyze-task-pipeline-interval | FileCheck %s
+//
+// CHECK-LABEL: func.func @chain_reuse_cgra1
+// CHECK-SAME: task_pipeline_interval_info = {bottleneck_task = "Task_2",
+// CHECK-SAME: critical_path = ["Task_1", "Task_2"]
+// CHECK-SAME: pipeline_interval = 8 : i32
+
+module {
+  func.func @chain_reuse_cgra1(%seed: i32) -> i32 {
+    %t0 = taskflow.task @Task_0 value_inputs(%seed : i32)
+        {profile_info = {duration = 2 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    %t1 = taskflow.task @Task_1 value_inputs(%t0 : i32)
+        {profile_info = {duration = 3 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    %t2 = taskflow.task @Task_2 value_inputs(%t1 : i32)
+        {profile_info = {duration = 5 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    return %t2 : i32
+  }
+}

--- a/test/multi-cgra/taskflow/pipeline-interval/diamond_join.mlir
+++ b/test/multi-cgra/taskflow/pipeline-interval/diamond_join.mlir
@@ -1,0 +1,70 @@
+// Hand-written schedule-analysis case for TaskPipelineIntervalAnalyzer.
+//
+// Data dependence: T0 -> T2, T1 -> T2, T2 -> T3
+// CGRA0: T0, then T2
+// CGRA1: T1, then T3
+//
+// Expected analysis graph:
+//   Data-dependence edges:     T0 -> T2, T1 -> T2, T2 -> T3
+//   CGRA execution-order edge: T0 -> T2, T1 -> T3
+//
+// Expected pipeline cycles:
+//   CGRA0: T0(this input) -> T2 -> T0(next input)
+//          interval = 4 + 6 = 10
+//   CGRA1: T1(this input) -> T2 -> T3 -> T1(next input)
+//          interval = 1 + 6 + 2 = 9
+//
+// Expected pipeline interval: 10
+
+// RUN: mlir-neura-opt %s --analyze-task-pipeline-interval | FileCheck %s
+//
+// CHECK-LABEL: func.func @diamond_join
+// CHECK-SAME: task_pipeline_interval_info = {bottleneck_task = "Task_2",
+// CHECK-SAME: critical_path = ["Task_0", "Task_2"]
+// CHECK-SAME: pipeline_interval = 10 : i32
+
+module {
+  func.func @diamond_join(%seed0: i32, %seed1: i32) -> i32 {
+    %t0 = taskflow.task @Task_0 value_inputs(%seed0 : i32)
+        {profile_info = {duration = 4 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    %t1 = taskflow.task @Task_1 value_inputs(%seed1 : i32)
+        {profile_info = {duration = 1 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 0 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    %t2 = taskflow.task @Task_2 value_inputs(%t0, %t1 : i32, i32)
+        {profile_info = {duration = 6 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32, i32) -> (i32) {
+    ^bb0(%arg0: i32, %arg1: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    %t3 = taskflow.task @Task_3 value_inputs(%t2 : i32)
+        {profile_info = {duration = 2 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 1 : i32, context_id = 1 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    return %t3 : i32
+  }
+}

--- a/test/multi-cgra/taskflow/pipeline-interval/independent_temporal_pack.mlir
+++ b/test/multi-cgra/taskflow/pipeline-interval/independent_temporal_pack.mlir
@@ -1,0 +1,47 @@
+// Hand-written schedule-analysis case for TaskPipelineIntervalAnalyzer.
+//
+// Data dependence: none
+// CGRA0: T0, then T1
+//
+// Expected analysis graph:
+//   Data-dependence edges:     none
+//   CGRA execution-order edge: T0 -> T1
+//
+// Expected pipeline cycle:
+//   CGRA0: T0(this input) -> T1 -> T0(next input)
+//          interval = 7 + 2 = 9
+//
+// Expected pipeline interval: 9
+
+// RUN: mlir-neura-opt %s --analyze-task-pipeline-interval | FileCheck %s
+//
+// CHECK-LABEL: func.func @independent_temporal_pack
+// CHECK-SAME: task_pipeline_interval_info = {bottleneck_task = "Task_0",
+// CHECK-SAME: critical_path = ["Task_0", "Task_1"]
+// CHECK-SAME: pipeline_interval = 9 : i32
+
+module {
+  func.func @independent_temporal_pack(%seed0: i32, %seed1: i32) -> (i32, i32) {
+    %t0 = taskflow.task @Task_0 value_inputs(%seed0 : i32)
+        {profile_info = {duration = 7 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 0 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    %t1 = taskflow.task @Task_1 value_inputs(%seed1 : i32)
+        {profile_info = {duration = 2 : i32},
+         task_orchestration_info = {cgra_positions = [{col = 0 : i32, context_id = 1 : i32, row = 0 : i32}],
+                                    read_sram_locations = [],
+                                    write_sram_locations = []}}
+        : (i32) -> (i32) {
+    ^bb0(%arg0: i32):
+      taskflow.yield values(%arg0 : i32)
+    }
+
+    return %t0, %t1 : i32, i32
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds an analysis pass for already-scheduled Taskflow programs. Given tasks with `profile_info.duration` and `task_orchestration_info.cgra_positions`, the pass reconstructs the task execution order from data dependencies and per-CGRA context order, then reports the schedule’s pipeline interval, bottleneck task, and critical path.

## Changes:
- Add `TaskScheduleResult` to represent concrete per-task scheduling facts.
- Add `TaskPipelineIntervalAnalyzer` to compute the pipeline interval from task dependencies and CGRA context reuse.
- Add `--analyze-task-pipeline-interval`, which emits `task_pipeline_interval_info` on the parent func.func.
- Add focused tests for: temporal reuse on different CGRAs, dependency chains, diamond-shaped task graphs, and independent tasks on one CGRA

## Terminology
- Pipeline interval: the steady-state time gap between two consecutive completed executions of the scheduled task graph. It measures how often the scheduled pipeline can produce results after warm-up.
- Per-CGRA context reuse: multiple tasks sharing the same physical CGRA at different context slots, which adds ordering constraints beyond data dependencies.