### PR TITLE
Add expand-memref-copy pass to unblock linalg.matmul -> Neura ingestion

### DIFF
--- a/include/Conversion/NeuraConversionPasses.h
+++ b/include/Conversion/NeuraConversionPasses.h
@@ -20,6 +20,7 @@ std::unique_ptr<mlir::Pass> createLowerMemRefToNeuraPass();
 std::unique_ptr<mlir::Pass> createLowerBuiltinToNeuraPass();
 std::unique_ptr<mlir::Pass> createLowerTorchToNeuraPass();
 std::unique_ptr<mlir::Pass> createLowerAffineToNeuraPass();
+std::unique_ptr<mlir::Pass> createExpandMemrefCopyPass();
 
 #define GEN_PASS_REGISTRATION
 #include "Conversion/NeuraConversionPasses.h.inc"

--- a/include/Conversion/NeuraConversionPasses.td
+++ b/include/Conversion/NeuraConversionPasses.td
@@ -59,4 +59,18 @@ def LowerAffineToNeura : Pass<"lower-affine-to-neura", "func::FuncOp"> {
                            "mlir::affine::AffineDialect"];
 }
 
+def ExpandMemrefCopy : Pass<"expand-memref-copy", "ModuleOp"> {
+  let summary = "Expand memref.copy into an explicit nested affine.for loop";
+  let description = [{
+    Rewrites memref.copy(src, dst) into a nested affine.for loop that loads
+    from src and stores to dst element by element. Bufferization commonly
+    leaves a trailing memref.copy (e.g. via -buffer-results-to-out-params)
+    that no Neura lowering pass understands; this lets it flow through the
+    same affine-loop-based path (--lower-affine-to-neura) as the rest of a
+    kernel body instead of needing dedicated support for memref.copy itself.
+  }];
+  let constructor = "mlir::createExpandMemrefCopyPass()";
+  let dependentDialects = ["mlir::affine::AffineDialect"];
+}
+
 #endif // NEURA_CONVERSION_PASSES_TD

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(LlvmToNeura)
 add_subdirectory(MemRefToNeura)
 add_subdirectory(BuiltinToNeura)
 add_subdirectory(TorchToNeura)
+add_subdirectory(MemrefCopyExpand)
 
 add_library(MLIRNeuraConversion INTERFACE)
 
@@ -23,5 +24,6 @@ target_link_libraries(MLIRNeuraConversion INTERFACE
   MLIRNeuraMemRefToNeuraPass
   MLIRNeuraBuiltinToNeuraPass
   MLIRNeuraTorchToNeuraPass
+  MLIRNeuraMemrefCopyExpandPass
   ${dialect_libs}
 )

--- a/lib/Conversion/MemrefCopyExpand/CMakeLists.txt
+++ b/lib/Conversion/MemrefCopyExpand/CMakeLists.txt
@@ -1,0 +1,16 @@
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_mlir_conversion_library(MLIRNeuraMemrefCopyExpandPass
+  ExpandMemrefCopyPass.cpp
+
+  DEPENDS
+  MLIRNeuraConversionIncGen
+
+  LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRPass
+    MLIRSupport
+    MLIRTransforms
+    MLIRAffineDialect
+    MLIRMemRefDialect
+)

--- a/lib/Conversion/MemrefCopyExpand/CMakeLists.txt
+++ b/lib/Conversion/MemrefCopyExpand/CMakeLists.txt
@@ -13,4 +13,5 @@ add_mlir_conversion_library(MLIRNeuraMemrefCopyExpandPass
     MLIRTransforms
     MLIRAffineDialect
     MLIRMemRefDialect
+    MLIRArithDialect
 )

--- a/lib/Conversion/MemrefCopyExpand/ExpandMemrefCopyPass.cpp
+++ b/lib/Conversion/MemrefCopyExpand/ExpandMemrefCopyPass.cpp
@@ -1,0 +1,89 @@
+#include "Conversion/NeuraConversionPasses.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+using namespace mlir;
+
+namespace {
+
+// Expands memref.copy(src, dst) into an explicit nested affine.for loop that
+// copies src to dst element by element. Bufferization (e.g.
+// -buffer-results-to-out-params) commonly leaves a trailing memref.copy that
+// no Neura lowering pass understands; rewriting it into plain affine
+// load/store lets it flow through the same, already-supported
+// --lower-affine-to-neura path as the rest of the kernel body, instead of
+// needing a dedicated Neura-side lowering for memref.copy itself.
+struct MemrefCopyToAffineLoop : public OpRewritePattern<memref::CopyOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::CopyOp copy_op,
+                                PatternRewriter &rewriter) const override {
+    Value src = copy_op.getSource();
+    Value dst = copy_op.getTarget();
+    auto memref_type = dyn_cast<MemRefType>(src.getType());
+    if (!memref_type || !memref_type.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(
+          copy_op, "expects a statically-shaped memref");
+    }
+
+    Location loc = copy_op.getLoc();
+    ArrayRef<int64_t> shape = memref_type.getShape();
+
+    // Builds one affine.for per dimension, nesting each new loop inside the
+    // previous one's body, then loads from src and stores to dst at the
+    // innermost level using the collected induction variables as indices.
+    SmallVector<Value> indices;
+    for (int64_t dim_size : shape) {
+      auto for_op = rewriter.create<affine::AffineForOp>(loc, 0, dim_size);
+      rewriter.setInsertionPointToStart(for_op.getBody());
+      indices.push_back(for_op.getInductionVar());
+    }
+    Value loaded = rewriter.create<affine::AffineLoadOp>(loc, src, indices);
+    rewriter.create<affine::AffineStoreOp>(loc, loaded, dst, indices);
+
+    rewriter.eraseOp(copy_op);
+    return success();
+  }
+};
+
+struct ExpandMemrefCopyPass
+    : public PassWrapper<ExpandMemrefCopyPass, OperationPass<ModuleOp>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ExpandMemrefCopyPass)
+
+  StringRef getArgument() const override { return "expand-memref-copy"; }
+
+  StringRef getDescription() const override {
+    return "Expands memref.copy into an explicit nested affine.for loop";
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<affine::AffineDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module_op = getOperation();
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    patterns.add<MemrefCopyToAffineLoop>(context);
+    if (failed(applyPatternsGreedily(module_op, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> mlir::createExpandMemrefCopyPass() {
+  return std::make_unique<ExpandMemrefCopyPass>();
+}

--- a/lib/Conversion/MemrefCopyExpand/ExpandMemrefCopyPass.cpp
+++ b/lib/Conversion/MemrefCopyExpand/ExpandMemrefCopyPass.cpp
@@ -1,7 +1,9 @@
 #include "Conversion/NeuraConversionPasses.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
@@ -27,28 +29,72 @@ struct MemrefCopyToAffineLoop : public OpRewritePattern<memref::CopyOp> {
 
   LogicalResult matchAndRewrite(memref::CopyOp copy_op,
                                 PatternRewriter &rewriter) const override {
+    // If the copy's target has no other users, the copy may be dead (nothing
+    // in this region ever reads the destination), so it can be dropped
+    // instead of materializing a loop nest for it. This only holds for a
+    // value whose lifetime is local to this region (e.g. a memref.alloc or
+    // memref.subview) -- a block argument (a function parameter, most
+    // commonly an out-param from -buffer-results-to-out-params) escapes to
+    // the caller, so "no readers in this function" does not mean "unread":
+    // erasing the copy there would silently drop the function's actual
+    // output.
+    Value target = copy_op.getTarget();
+    if (!isa<BlockArgument>(target)) {
+      bool has_other_users = false;
+      for (Operation *user : target.getUsers()) {
+        if (user != copy_op.getOperation()) {
+          has_other_users = true;
+          break;
+        }
+      }
+      if (!has_other_users) {
+        rewriter.eraseOp(copy_op);
+        return success();
+      }
+    }
+
     Value src = copy_op.getSource();
-    Value dst = copy_op.getTarget();
     auto memref_type = dyn_cast<MemRefType>(src.getType());
-    if (!memref_type || !memref_type.hasStaticShape()) {
-      return rewriter.notifyMatchFailure(
-          copy_op, "expects a statically-shaped memref");
+    if (!memref_type) {
+      return rewriter.notifyMatchFailure(copy_op, "expects a memref source");
     }
 
     Location loc = copy_op.getLoc();
-    ArrayRef<int64_t> shape = memref_type.getShape();
+
+    // Builds the affine bound for one dimension: a constant map for a
+    // statically-sized dimension, or a single-symbol map reading the
+    // dimension's runtime size (via memref.dim) for a dynamic one.
+    auto makeBound =
+        [&](int64_t dim_size) -> std::pair<AffineMap, SmallVector<Value>> {
+      if (ShapedType::isDynamic(dim_size)) {
+        return {AffineMap::get(/*dimCount=*/0, /*symbolCount=*/1,
+                               rewriter.getAffineSymbolExpr(0)),
+                {}};
+      }
+      return {AffineMap::getConstantMap(dim_size, rewriter.getContext()), {}};
+    };
 
     // Builds one affine.for per dimension, nesting each new loop inside the
     // previous one's body, then loads from src and stores to dst at the
     // innermost level using the collected induction variables as indices.
     SmallVector<Value> indices;
-    for (int64_t dim_size : shape) {
-      auto for_op = rewriter.create<affine::AffineForOp>(loc, 0, dim_size);
+    for (int i = 0; i < memref_type.getRank(); ++i) {
+      int64_t dim_size = memref_type.getShape()[i];
+      auto [ub_map, ub_operands] = makeBound(dim_size);
+      if (ShapedType::isDynamic(dim_size)) {
+        Value dim_index = rewriter.create<arith::ConstantIndexOp>(loc, i);
+        ub_operands.push_back(
+            rewriter.create<memref::DimOp>(loc, src, dim_index));
+      }
+      auto for_op = rewriter.create<affine::AffineForOp>(
+          loc, /*lbOperands=*/ValueRange{},
+          AffineMap::getConstantMap(0, rewriter.getContext()), ub_operands,
+          ub_map, /*step=*/1);
       rewriter.setInsertionPointToStart(for_op.getBody());
       indices.push_back(for_op.getInductionVar());
     }
     Value loaded = rewriter.create<affine::AffineLoadOp>(loc, src, indices);
-    rewriter.create<affine::AffineStoreOp>(loc, loaded, dst, indices);
+    rewriter.create<affine::AffineStoreOp>(loc, loaded, target, indices);
 
     rewriter.eraseOp(copy_op);
     return success();
@@ -67,7 +113,8 @@ struct ExpandMemrefCopyPass
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<affine::AffineDialect>();
+    registry.insert<affine::AffineDialect, arith::ArithDialect,
+                    memref::MemRefDialect>();
   }
 
   void runOnOperation() override {

--- a/test/Conversion/linalg2neura/expand-memref-copy-dynamic-and-dead.mlir
+++ b/test/Conversion/linalg2neura/expand-memref-copy-dynamic-and-dead.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-neura-opt %s --expand-memref-copy | FileCheck %s
+
+// Dynamic shape: bounds must come from memref.dim, not a constant.
+func.func @copy_dynamic(%src: memref<?x4xf32>, %dst: memref<?x4xf32>) {
+  memref.copy %src, %dst : memref<?x4xf32> to memref<?x4xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @copy_dynamic
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[DIM:.*]] = memref.dim %arg0, %[[C0]]
+// CHECK: affine.for %{{.*}} = 0 to %[[DIM]]
+// CHECK: affine.for %{{.*}} = 0 to 4
+// CHECK: affine.load %arg0
+// CHECK: affine.store %{{.*}}, %arg1
+// CHECK-NOT: memref.copy
+
+// Dead copy: target has no other users, so the copy should just disappear.
+func.func @copy_dead(%src: memref<4xf32>) {
+  %dst = memref.alloc() : memref<4xf32>
+  memref.copy %src, %dst : memref<4xf32> to memref<4xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @copy_dead
+// CHECK-NOT: affine.for
+// CHECK-NOT: memref.copy

--- a/test/Conversion/linalg2neura/expand-memref-copy-dynamic-and-dead.mlir
+++ b/test/Conversion/linalg2neura/expand-memref-copy-dynamic-and-dead.mlir
@@ -1,4 +1,6 @@
-// RUN: mlir-neura-opt %s --expand-memref-copy | FileCheck %s
+// RUN: mlir-neura-opt %s --expand-memref-copy \
+// RUN: -o %t-expand.mlir
+// RUN: FileCheck %s --input-file=%t-expand.mlir
 
 // Dynamic shape: bounds must come from memref.dim, not a constant.
 func.func @copy_dynamic(%src: memref<?x4xf32>, %dst: memref<?x4xf32>) {
@@ -6,22 +8,27 @@ func.func @copy_dynamic(%src: memref<?x4xf32>, %dst: memref<?x4xf32>) {
   return
 }
 
-// CHECK-LABEL: func.func @copy_dynamic
-// CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: %[[DIM:.*]] = memref.dim %arg0, %[[C0]]
-// CHECK: affine.for %{{.*}} = 0 to %[[DIM]]
-// CHECK: affine.for %{{.*}} = 0 to 4
-// CHECK: affine.load %arg0
-// CHECK: affine.store %{{.*}}, %arg1
+// CHECK-LABEL: func.func @copy_dynamic(%arg0: memref<?x4xf32>, %arg1: memref<?x4xf32>)
+// CHECK-NEXT: %c0 = arith.constant 0 : index
+// CHECK-NEXT: %dim = memref.dim %arg0, %c0 : memref<?x4xf32>
+// CHECK-NEXT: affine.for %arg2 = 0 to %dim {
+// CHECK-NEXT:   affine.for %arg3 = 0 to 4 {
+// CHECK-NEXT:     %0 = affine.load %arg0[%arg2, %arg3] : memref<?x4xf32>
+// CHECK-NEXT:     affine.store %0, %arg1[%arg2, %arg3] : memref<?x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: return
 // CHECK-NOT: memref.copy
 
-// Dead copy: target has no other users, so the copy should just disappear.
+// Dead copy: target has no other users, so the copy should just disappear
+// (and the now-unused alloc is cleaned up too).
 func.func @copy_dead(%src: memref<4xf32>) {
   %dst = memref.alloc() : memref<4xf32>
   memref.copy %src, %dst : memref<4xf32> to memref<4xf32>
   return
 }
 
-// CHECK-LABEL: func.func @copy_dead
-// CHECK-NOT: affine.for
+// CHECK-LABEL: func.func @copy_dead(%arg0: memref<4xf32>)
+// CHECK-NEXT: return
+// CHECK-NOT: memref.alloc
 // CHECK-NOT: memref.copy

--- a/test/Conversion/linalg2neura/expand-memref-copy.mlir
+++ b/test/Conversion/linalg2neura/expand-memref-copy.mlir
@@ -1,0 +1,13 @@
+// RUN: mlir-neura-opt %s --expand-memref-copy | FileCheck %s
+
+func.func @copy_2d(%src: memref<4x4xf32>, %dst: memref<4x4xf32>) {
+  memref.copy %src, %dst : memref<4x4xf32> to memref<4x4xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @copy_2d
+// CHECK: affine.for
+// CHECK: affine.for
+// CHECK: %[[V:.*]] = affine.load %arg0
+// CHECK: affine.store %[[V]], %arg1
+// CHECK-NOT: memref.copy

--- a/test/Conversion/linalg2neura/expand-memref-copy.mlir
+++ b/test/Conversion/linalg2neura/expand-memref-copy.mlir
@@ -1,13 +1,18 @@
-// RUN: mlir-neura-opt %s --expand-memref-copy | FileCheck %s
+// RUN: mlir-neura-opt %s --expand-memref-copy \
+// RUN: -o %t-expand.mlir
+// RUN: FileCheck %s --input-file=%t-expand.mlir
 
 func.func @copy_2d(%src: memref<4x4xf32>, %dst: memref<4x4xf32>) {
   memref.copy %src, %dst : memref<4x4xf32> to memref<4x4xf32>
   return
 }
 
-// CHECK-LABEL: func.func @copy_2d
-// CHECK: affine.for
-// CHECK: affine.for
-// CHECK: %[[V:.*]] = affine.load %arg0
-// CHECK: affine.store %[[V]], %arg1
+// CHECK-LABEL: func.func @copy_2d(%arg0: memref<4x4xf32>, %arg1: memref<4x4xf32>)
+// CHECK-NEXT: affine.for %arg2 = 0 to 4 {
+// CHECK-NEXT:   affine.for %arg3 = 0 to 4 {
+// CHECK-NEXT:     %0 = affine.load %arg0[%arg2, %arg3] : memref<4x4xf32>
+// CHECK-NEXT:     affine.store %0, %arg1[%arg2, %arg3] : memref<4x4xf32>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: return
 // CHECK-NOT: memref.copy

--- a/test/Conversion/linalg2neura/matmul.mlir
+++ b/test/Conversion/linalg2neura/matmul.mlir
@@ -1,0 +1,43 @@
+// Compiles a linalg.matmul (tensor-level, the shape torch-mlir produces for
+// real models) through bufferization and the affine-based Neura pipeline,
+// all the way to a mapped, code-generated program. This exercises the
+// linalg -> affine -> neura ingestion path end to end: bufferize, expand the
+// trailing memref.copy that -buffer-results-to-out-params leaves behind,
+// lower to affine loops, then through the existing affine-sourced Neura
+// pipeline (see test/neura/for_loop for the analogous LLVM-sourced path).
+//
+// RUN: mlir-opt %s -one-shot-bufferize="bufferize-function-boundaries" -buffer-results-to-out-params \
+// RUN:   | mlir-neura-opt --expand-memref-copy \
+// RUN:   | mlir-opt -convert-linalg-to-affine-loops \
+// RUN:   | mlir-neura-opt \
+// RUN:       --assign-accelerator \
+// RUN:       --lower-affine-to-neura \
+// RUN:       --lower-arith-to-neura \
+// RUN:       --promote-input-arg-to-const \
+// RUN:       --fold-constant \
+// RUN:       --canonicalize-return \
+// RUN:       --canonicalize-live-in \
+// RUN:       --leverage-predicated-value \
+// RUN:       --insert-data-mov \
+// RUN:       --map-to-accelerator="mapping-strategy=heuristic" \
+// RUN:       --architecture-spec=%S/../../arch_spec/architecture.yaml \
+// RUN:   | FileCheck %s
+
+func.func @matmul(%a: tensor<4x4xf32>, %b: tensor<4x4xf32>) -> tensor<4x4xf32> {
+  %cst = arith.constant 0.0 : f32
+  %init = tensor.empty() : tensor<4x4xf32>
+  %c = linalg.fill ins(%cst : f32) outs(%init : tensor<4x4xf32>) -> tensor<4x4xf32>
+  %0 = linalg.matmul ins(%a, %b : tensor<4x4xf32>, tensor<4x4xf32>) outs(%c : tensor<4x4xf32>) -> tensor<4x4xf32>
+  return %0 : tensor<4x4xf32>
+}
+
+// CHECK-LABEL: func.func @matmul
+// CHECK-SAME: mapping_info
+// CHECK: neura.loop_control
+// CHECK: neura.load_indexed
+// CHECK: neura.fmul
+// CHECK: neura.fadd
+// CHECK: neura.store_indexed
+// CHECK-NOT: linalg.matmul
+// CHECK-NOT: memref.copy
+// CHECK-NOT: affine.for

--- a/test/Conversion/linalg2neura/matmul.mlir
+++ b/test/Conversion/linalg2neura/matmul.mlir
@@ -21,7 +21,8 @@
 // RUN:       --insert-data-mov \
 // RUN:       --map-to-accelerator="mapping-strategy=heuristic" \
 // RUN:       --architecture-spec=%S/../../arch_spec/architecture.yaml \
-// RUN:   | FileCheck %s
+// RUN:   -o %t-mapped.mlir
+// RUN: FileCheck %s --input-file=%t-mapped.mlir
 
 func.func @matmul(%a: tensor<4x4xf32>, %b: tensor<4x4xf32>) -> tensor<4x4xf32> {
   %cst = arith.constant 0.0 : f32


### PR DESCRIPTION
## Summary
- `-buffer-results-to-out-params` (standard bufferization for a tensor-returning function) leaves a trailing `memref.copy` that no existing Neura lowering pass understands, which breaks the `linalg` -> `affine` -> Neura path for any kernel shaped like what torch-mlir produces for real models (compute into a temp buffer, copy into the out-param).
- Adds `--expand-memref-copy`, a small new pass that rewrites `memref.copy(src, dst)` into an explicit `affine.for` loop with `affine.load`/`affine.store`. This lets it flow through the already-supported `--lower-affine-to-neura` path like the rest of a kernel body, instead of needing dedicated Neura-side support for `memref.copy` itself. Tried `-drop-equivalent-buffer-results` and `-memref-expand` first; neither touches this case.
- Confirms (and documents via the new e2e test) that the existing `--lower-affine-to-neura` path — not a detour through LLVM dialect — is the right route for structured loop-nest kernels (matmul/conv/elementwise) coming from `linalg`, matching the pass's own stated design intent of avoiding an LLVM round-trip.

## Test plan
- [x] New lit test `test/Conversion/linalg2neura/expand-memref-copy.mlir` — the pass in isolation.
- [x] New lit test `test/Conversion/linalg2neura/matmul.mlir` — a tensor-level `linalg.matmul` (bufferize -> expand-memref-copy -> `-convert-linalg-to-affine-loops` -> the full affine-sourced Neura pipeline) mapped end-to-end onto `test/arch_spec/architecture.yaml`, with `FileCheck` verifying no `linalg.matmul`/`memref.copy`/`affine.for` survive and the expected Neura ops (`loop_control`, `load_indexed`, `fmul`, `fadd`, `store_indexed`) are present.
- [x] Full existing suite still passes: 93/94 (only `frontend/gather/gather.mlir`, which needs `torch` installed, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)