### PR TITLE
Refactor RecMII calculation into a shared mapping utility

### DIFF
--- a/include/NeuraDialect/Mapping/mapping_util.h
+++ b/include/NeuraDialect/Mapping/mapping_util.h
@@ -3,6 +3,7 @@
 #include "NeuraDialect/Architecture/Architecture.h"
 #include "NeuraDialect/Mapping/MappingState.h"
 #include "mlir/IR/Operation.h"
+#include "llvm/ADT/ArrayRef.h"
 
 namespace mlir {
 namespace neura {
@@ -31,6 +32,9 @@ struct RecurrenceCycle {
 
 // Collects recurrence cycles rooted at reserve and closed by ctrl_mov.
 SmallVector<RecurrenceCycle, 4> collectRecurrenceCycles(Region &region);
+
+// Calculates RecMII from recurrence cycles, defaulting to one when none exist.
+int calculateRecMii(llvm::ArrayRef<RecurrenceCycle> recurrence_cycles);
 
 // Calculates ResMII: ceil(#ops / #tiles).
 int calculateResMii(Region &region, const Architecture &architecture);

--- a/lib/NeuraDialect/Mapping/mapping_util.cpp
+++ b/lib/NeuraDialect/Mapping/mapping_util.cpp
@@ -227,6 +227,19 @@ mlir::neura::collectRecurrenceCycles(Region &region) {
   return recurrence_cycles;
 }
 
+int mlir::neura::calculateRecMii(
+    llvm::ArrayRef<RecurrenceCycle> recurrence_cycles) {
+  if (recurrence_cycles.empty()) {
+    return 1;
+  }
+
+  int rec_mii = recurrence_cycles.front().length;
+  for (const RecurrenceCycle &cycle : recurrence_cycles.drop_front()) {
+    rec_mii = std::max(rec_mii, cycle.length);
+  }
+  return rec_mii;
+}
+
 int mlir::neura::calculateResMii(Region &region,
                                  const Architecture &architecture) {
   int num_ops = 0;

--- a/lib/NeuraDialect/Transforms/MapToAcceleratorPass.cpp
+++ b/lib/NeuraDialect/Transforms/MapToAcceleratorPass.cpp
@@ -236,7 +236,6 @@ struct MapToAcceleratorPass
     auto recurrence_cycles = collectRecurrenceCycles(region);
     std::set<Operation *> critical_ops;
     RecurrenceCycle *longest = nullptr;
-    int rec_mii = 1;
     for (auto &cycle : recurrence_cycles) {
       llvm::outs() << "[DEBUG] Recurrence cycle (length " << cycle.length
                    << "):\n";
@@ -255,10 +254,9 @@ struct MapToAcceleratorPass
       for (Operation *op : longest->operations) {
         op->print(llvm::outs()), llvm::outs() << "\n";
       }
-      rec_mii = longest->length;
-    } else if (!longest) {
-      rec_mii = 1; // No recurrence cycles found, set MII to 1.
     }
+
+    int rec_mii = calculateRecMii(recurrence_cycles);
 
     llvm::errs() << "[MapToAcceleratorPass] Calculated Recurrence MII: "
                  << rec_mii << "\n";


### PR DESCRIPTION
## Summary

- Add a shared calculateRecMii helper to mapping_util.
- Make MapToAcceleratorPass call the helper instead of duplicating the RecMII reduction.
- Preserve the existing RecMII behavior and leave existing lit tests unchanged.

## Motivation

Expose the RecMII calculation already used on main as a reusable API, so downstream II prediction can call Neura directly without copying the formula.

