### PR TITLE
Handle mapped form of neura.icmp in interpreter

### DIFF
--- a/test/neura/interpreter/basic_operation/icmp.mlir
+++ b/test/neura/interpreter/basic_operation/icmp.mlir
@@ -169,6 +169,24 @@ func.func @test_icmp_ugt_false() -> i1 {
   return %ugt : i1
 }
 
+// ====== Mapped form — single SSA operand with rhs_value attribute ======
+// After --map-to-accelerator, compile-time constant operands are folded into
+// rhs_value attributes (e.g. "neura.icmp"(%x) {cmpType = "sge", rhs_value = 0 : i32}).
+// Before this fix, the interpreter rejected any op with numOperands < 2.
+func.func @test_icmp_mapped_form_true() -> !neura.data<i1, i1> {
+  %a = "neura.grant_once"() <{constant_value = 5 : i32}> : () -> !neura.data<i32, i1>
+  %res = "neura.icmp"(%a) {cmpType = "sge", rhs_value = 0 : i32} : (!neura.data<i32, i1>) -> !neura.data<i1, i1>
+  // CHECK: [neura-interpreter]  → Output: 1.000000
+  return %res : !neura.data<i1, i1>
+}
+
+func.func @test_icmp_mapped_form_false() -> !neura.data<i1, i1> {
+  %a = "neura.grant_once"() <{constant_value = -5 : i32}> : () -> !neura.data<i32, i1>
+  %res = "neura.icmp"(%a) {cmpType = "sge", rhs_value = 0 : i32} : (!neura.data<i32, i1>) -> !neura.data<i1, i1>
+  // CHECK: [neura-interpreter]  → Output: 0.000000
+  return %res : !neura.data<i1, i1>
+}
+
 // ====== Unsigned greater than or equal (uge) ======
 // Positive case: lhs >= rhs (unsigned)
 func.func @test_icmp_uge_true() -> i1 {

--- a/tools/neura-interpreter/neura-interpreter.cpp
+++ b/tools/neura-interpreter/neura-interpreter.cpp
@@ -482,6 +482,54 @@ bool handleNeuraConstantOp(
  * @return bool                          True if the constant is successfully
  * parsed and stored; false if the constant type is unsupported
  */
+/**
+ * @brief Resolves the LHS/RHS operands for a binary op that supports both
+ * the pre-mapping two-operand form and the post-mapping single-operand form.
+ *
+ * After --map-to-accelerator, FoldConstantPass folds compile-time constant
+ * operands into a rhs_value attribute, leaving a single SSA operand (the
+ * LHS). This is the shape shared by every binary neura op whose $rhs field
+ * is Optional<AnyType> in NeuraOps.td (e.g. AddOp, ICmpOp) — the mapper
+ * always folds into the same slot, so one resolver covers all of them.
+ *
+ * @param op          The op being handled (must have 1-2 operands + optional
+ * rhs_value attribute)
+ * @param op_name     Name used in diagnostics, e.g. "neura.add"
+ * @param lhs, rhs    Out params, populated on success
+ * @return bool       True if operands were resolved; false (with a
+ * diagnostic in verbose mode) if the op has zero operands or a single
+ * operand without a rhs_value attribute
+ */
+bool resolveBinaryOperands(
+    mlir::Operation *op, const char *op_name,
+    llvm::DenseMap<Value, PredicatedData> &value_to_predicated_data_map,
+    PredicatedData &lhs, PredicatedData &rhs) {
+  if (op->getNumOperands() >= 2) {
+    lhs = value_to_predicated_data_map[op->getOperand(0)];
+    rhs = value_to_predicated_data_map[op->getOperand(1)];
+    return true;
+  }
+  if (op->getNumOperands() == 1) {
+    auto rhs_attr = op->getAttrOfType<mlir::IntegerAttr>("rhs_value");
+    if (!rhs_attr) {
+      if (isVerboseMode()) {
+        llvm::errs() << "[neura-interpreter]  └─ " << op_name
+                     << ": single-operand form requires rhs_value attribute\n";
+      }
+      return false;
+    }
+    lhs = value_to_predicated_data_map[op->getOperand(0)];
+    rhs.value = static_cast<float>(rhs_attr.getInt());
+    rhs.predicate = true; // compile-time constant is always valid
+    rhs.is_vector = false;
+    return true;
+  }
+  if (isVerboseMode()) {
+    llvm::errs() << "[neura-interpreter]  └─ " << op_name << ": no operands\n";
+  }
+  return false;
+}
+
 bool handleAddOp(
     neura::AddOp op,
     llvm::DenseMap<Value, PredicatedData> &value_to_predicated_data_map) {
@@ -489,31 +537,9 @@ bool handleAddOp(
     llvm::outs() << "[neura-interpreter]  Executing neura.add:\n";
   }
 
-  // After --map-to-accelerator, compile-time constant operands are folded into
-  // rhs_value attributes, leaving a single SSA operand (the LHS). The $rhs
-  // field in AddOp is Optional<AnyType> (NeuraOps.td) precisely to support this
-  // single-operand mapped form alongside the two-operand pre-mapping form.
   PredicatedData lhs, rhs;
-  if (op.getNumOperands() >= 2) {
-    lhs = value_to_predicated_data_map[op.getLhs()];
-    rhs = value_to_predicated_data_map[op.getRhs()];
-  } else if (op.getNumOperands() == 1) {
-    auto rhs_attr = op->getAttrOfType<mlir::IntegerAttr>("rhs_value");
-    if (!rhs_attr) {
-      if (isVerboseMode()) {
-        llvm::errs() << "[neura-interpreter]  └─ neura.add: single-operand "
-                        "form requires rhs_value attribute\n";
-      }
-      return false;
-    }
-    lhs = value_to_predicated_data_map[op.getLhs()];
-    rhs.value = static_cast<float>(rhs_attr.getInt());
-    rhs.predicate = true; // compile-time constant is always valid
-    rhs.is_vector = false;
-  } else {
-    if (isVerboseMode()) {
-      llvm::errs() << "[neura-interpreter]  └─ neura.add: no operands\n";
-    }
+  if (!resolveBinaryOperands(op, "neura.add", value_to_predicated_data_map, lhs,
+                             rhs)) {
     return false;
   }
 
@@ -1607,32 +1633,9 @@ bool handleICmpOp(
   if (isVerboseMode()) {
     llvm::outs() << "[neura-interpreter]  Executing neura.icmp:\n";
   }
-  // After --map-to-accelerator, compile-time constant operands are folded into
-  // rhs_value attributes, leaving a single SSA operand (the LHS). The $rhs
-  // field in ICmpOp is Optional<AnyType> (NeuraOps.td) precisely to support
-  // this single-operand mapped form alongside the two-operand pre-mapping
-  // form. Same pattern as handleAddOp.
   PredicatedData lhs, rhs;
-  if (op.getNumOperands() >= 2) {
-    lhs = value_to_predicated_data_map[op.getLhs()];
-    rhs = value_to_predicated_data_map[op.getRhs()];
-  } else if (op.getNumOperands() == 1) {
-    auto rhs_attr = op->getAttrOfType<mlir::IntegerAttr>("rhs_value");
-    if (!rhs_attr) {
-      if (isVerboseMode()) {
-        llvm::errs() << "[neura-interpreter]  └─ neura.icmp: single-operand "
-                        "form requires rhs_value attribute\n";
-      }
-      return false;
-    }
-    lhs = value_to_predicated_data_map[op.getLhs()];
-    rhs.value = static_cast<float>(rhs_attr.getInt());
-    rhs.predicate = true; // compile-time constant is always valid
-    rhs.is_vector = false;
-  } else {
-    if (isVerboseMode()) {
-      llvm::errs() << "[neura-interpreter]  └─ neura.icmp: no operands\n";
-    }
+  if (!resolveBinaryOperands(op, "neura.icmp", value_to_predicated_data_map,
+                             lhs, rhs)) {
     return false;
   }
 

--- a/tools/neura-interpreter/neura-interpreter.cpp
+++ b/tools/neura-interpreter/neura-interpreter.cpp
@@ -1607,16 +1607,34 @@ bool handleICmpOp(
   if (isVerboseMode()) {
     llvm::outs() << "[neura-interpreter]  Executing neura.icmp:\n";
   }
-  if (op.getNumOperands() < 2) {
+  // After --map-to-accelerator, compile-time constant operands are folded into
+  // rhs_value attributes, leaving a single SSA operand (the LHS). The $rhs
+  // field in ICmpOp is Optional<AnyType> (NeuraOps.td) precisely to support
+  // this single-operand mapped form alongside the two-operand pre-mapping
+  // form. Same pattern as handleAddOp.
+  PredicatedData lhs, rhs;
+  if (op.getNumOperands() >= 2) {
+    lhs = value_to_predicated_data_map[op.getLhs()];
+    rhs = value_to_predicated_data_map[op.getRhs()];
+  } else if (op.getNumOperands() == 1) {
+    auto rhs_attr = op->getAttrOfType<mlir::IntegerAttr>("rhs_value");
+    if (!rhs_attr) {
+      if (isVerboseMode()) {
+        llvm::errs() << "[neura-interpreter]  └─ neura.icmp: single-operand "
+                        "form requires rhs_value attribute\n";
+      }
+      return false;
+    }
+    lhs = value_to_predicated_data_map[op.getLhs()];
+    rhs.value = static_cast<float>(rhs_attr.getInt());
+    rhs.predicate = true; // compile-time constant is always valid
+    rhs.is_vector = false;
+  } else {
     if (isVerboseMode()) {
-      llvm::errs() << "[neura-interpreter]  └─ neura.icmp expects at least two "
-                      "operands\n";
+      llvm::errs() << "[neura-interpreter]  └─ neura.icmp: no operands\n";
     }
     return false;
   }
-
-  auto lhs = value_to_predicated_data_map[op.getLhs()];
-  auto rhs = value_to_predicated_data_map[op.getRhs()];
 
   if (isVerboseMode()) {
     llvm::outs() << "[neura-interpreter]  ├─ Operands \n";


### PR DESCRIPTION
## Background

Same root cause as #322's neura.add fix. After --map-to-accelerator,
FoldConstantPass folds compile-time constant operands into a rhs_value
attribute:

    %res = "neura.icmp"(%lhs) {cmpType = "sge", rhs_value = 0 : i32}
             : (!neura.data<i32, i1>) -> !neura.data<i1, i1>

handleICmpOp unconditionally rejected any op with fewer than two SSA
operands. This blocks interpreting relu_neura_mapped.mlir, which uses
this exact form twice (the ReLU sign check and the loop-bound check).

## PR Summary

**Interpreter**
- Extend handleICmpOp to handle the single-operand mapped form, same
  pattern as the merged handleAddOp fix
- Retain the existing two-operand path unchanged
- Follow-up cleanup (per @ShangkunLi's suggestion on #322): extract the
  shared "single-operand + rhs_value attribute" resolution logic out of
  handleAddOp and handleICmpOp into one resolveBinaryOperands helper, so
  any future binary op needing this treatment doesn't have to copy-paste
  it again. Pure refactor, no behavior change.

**Tests**
- Add two cases to icmp.mlir modeled on the real mapped-IR usage:
  - test_icmp_mapped_form_true — grant_once constant 5, sge 0 → 1
  - test_icmp_mapped_form_false — grant_once constant -5, sge 0 → 0
- All 18 existing two-operand cases (eq, ne, slt, sle, sgt, sge, ult,
  ule, ugt, uge) continue to pass, confirming no regression on the
  pre-mapping path
- Full suite regression: 96/97 both before and after the cleanup
  commit (one pre-existing, unrelated local-environment failure —
  missing torch module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

